### PR TITLE
Fix or remove 'Open in Plex' feature

### DIFF
--- a/src/components/requests/RequestCard.tsx
+++ b/src/components/requests/RequestCard.tsx
@@ -7,7 +7,6 @@
 
 import React from 'react';
 import Image from 'next/image';
-import Link from 'next/link';
 import { StatusBadge } from './StatusBadge';
 import { Button } from '@/components/ui/Button';
 import { useCancelRequest } from '@/lib/hooks/useRequests';
@@ -187,15 +186,6 @@ export function RequestCard({ request, showActions = true }: RequestCardProps) {
               >
                 Cancel
               </Button>
-            )}
-
-            {request.status === 'completed' && (
-              <Link
-                href="/profile"
-                className="text-xs text-blue-600 dark:text-blue-400 hover:underline"
-              >
-                View in Plex →
-              </Link>
             )}
           </div>
         </div>


### PR DESCRIPTION
The link pointed to /profile instead of opening the actual item in Plex. Removed the link since proper Plex deep linking would require:
- Adding plexRatingKey to Audiobook model
- Database migration
- Plex server configuration lookup
- URL construction logic

Users can still find completed audiobooks directly in their Plex library.