### PR TITLE
Fix downloaded and available status labels

### DIFF
--- a/documentation/frontend/components.md
+++ b/documentation/frontend/components.md
@@ -34,7 +34,7 @@ src/components/
 
 **Requests**
 - **RequestCard** ✅ - Cover, title, author, status badge, progress bar, timestamps, cancel button
-- **StatusBadge** - Color-coded status (pending=yellow, downloading=purple, completed=green, failed=red). Shows "Initializing..." when downloading with 0% progress (fetching torrent info), "Downloading" when progress > 0%
+- **StatusBadge** - Color-coded status (pending=yellow, searching=blue, downloading=purple, downloaded=green, processing=orange, available=green, completed=green, failed=red, warn=orange, cancelled=gray). Shows "Initializing..." when downloading with 0% progress (fetching torrent info), "Downloading" when progress > 0%
 - **ProgressBar** - Animated fill with percentage
 - Active indicator: "Setting up..." with spinner when progress = 0%, "Active" with pulsing dot when progress > 0%
 

--- a/src/components/requests/StatusBadge.tsx
+++ b/src/components/requests/StatusBadge.tsx
@@ -32,6 +32,10 @@ export function StatusBadge({ status, progress, className }: StatusBadgeProps) {
       label: progress !== undefined && progress === 0 ? 'Initializing...' : 'Downloading',
       color: 'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200',
     },
+    downloaded: {
+      label: 'Downloaded',
+      color: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
+    },
     processing: {
       label: 'Processing',
       color: 'bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-200',
@@ -39,6 +43,10 @@ export function StatusBadge({ status, progress, className }: StatusBadgeProps) {
     awaiting_import: {
       label: 'Awaiting Import',
       color: 'bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-200',
+    },
+    available: {
+      label: 'Available',
+      color: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
     },
     completed: {
       label: 'Available',


### PR DESCRIPTION
Added proper status badge mappings for 'downloaded' and 'available' statuses that were previously falling back to lowercase gray text. Both now display with green success styling and proper capitalized labels ('Downloaded' and 'Available').

Updated documentation to reflect complete status badge mapping.