### PR TITLE
Fix request button disable logic for status states

### DIFF
--- a/src/lib/hooks/useRequests.ts
+++ b/src/lib/hooks/useRequests.ts
@@ -109,6 +109,9 @@ export function useCreateRequest() {
       // Revalidate requests list
       mutate((key) => typeof key === 'string' && key.includes('/api/requests'));
 
+      // Revalidate audiobook lists to update button states
+      mutate((key) => typeof key === 'string' && key.includes('/api/audiobooks'));
+
       return data.request;
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Unknown error';


### PR DESCRIPTION
When a user clicks the request button, the button now immediately shows as "Requested" without requiring a page refresh. This is accomplished by revalidating all audiobook endpoints (in addition to request endpoints) when a new request is created, which triggers SWR to refetch the data and update the UI with the latest isRequested and requestStatus values.