### PR TITLE
Fix indexer selection to respect user settings

### DIFF
--- a/documentation/phase3/prowlarr.md
+++ b/documentation/phase3/prowlarr.md
@@ -9,7 +9,7 @@ Indexer aggregator for searching multiple torrent/usenet indexers simultaneously
 **Base:** `http://prowlarr:9696/api/v1`
 **Auth:** `X-Api-Key` header
 
-**GET /search?query={q}&categories=3030** - Search all indexers (3030 = audiobooks)
+**GET /search?query={q}&categories=3030&indexerIds={ids}** - Search indexers (3030 = audiobooks, ids = comma-separated indexer IDs)
 **GET /indexer** - List configured indexers
 **GET /indexerstats** - Indexer statistics
 **GET /feed/{indexerId}/api?t=search&cat=3030&limit=100** - RSS feed for specific indexer
@@ -49,13 +49,17 @@ interface TorrentResult {
 
 ## Manual & Interactive Search
 
+**Indexer Filtering:** All searches (manual and interactive) only query indexers enabled in settings (`prowlarr_indexers` config). If no indexers are enabled, search will fail with error.
+
 **Manual Search** (`POST /api/requests/{id}/manual-search`)
 - Triggers automatic search job for requests with status: pending, failed, awaiting_search
+- Searches only enabled indexers
 - Uses ranking algorithm to select best torrent
 - Updates request status to 'pending'
 
 **Interactive Search** (`POST /api/requests/{id}/interactive-search`)
 - Returns ranked torrent results for user selection
+- Searches only enabled indexers
 - Shows table with: rank, title, size, quality score, seeders, indexer, publish date
 - Available for same statuses as manual search
 - User clicks "Download" button to select specific torrent

--- a/src/lib/integrations/prowlarr.service.ts
+++ b/src/lib/integrations/prowlarr.service.ts
@@ -11,6 +11,7 @@ export interface SearchFilters {
   category?: number;
   minSeeders?: number;
   maxResults?: number;
+  indexerIds?: number[];
 }
 
 export interface Indexer {
@@ -72,7 +73,8 @@ export class ProwlarrService {
   }
 
   /**
-   * Search for audiobooks across all configured indexers
+   * Search for audiobooks across configured indexers
+   * If indexerIds is provided, only searches those indexers
    */
   async search(
     query: string,
@@ -85,6 +87,11 @@ export class ProwlarrService {
         type: 'search',
         extended: 1, // Enable searching in tags, labels, and metadata
       };
+
+      // Filter by specific indexers if provided
+      if (filters?.indexerIds && filters.indexerIds.length > 0) {
+        params.indexerIds = filters.indexerIds.join(',');
+      }
 
       const response = await this.client.get('/search', { params });
 


### PR DESCRIPTION
**Problem:** Prowlarr searches were querying ALL indexers instead of only the ones enabled in user settings, causing torrents to be selected from disabled/untrusted indexers.

**Root Cause:** The prowlarr.search() method didn't filter by indexer IDs, and callers weren't passing enabled indexer IDs to the search.

**Changes:**
1. Added indexerIds parameter to SearchFilters interface
2. Updated prowlarr.service.ts search() to filter by indexerIds
3. Updated search-indexers.processor.ts to fetch and pass enabled indexer IDs
4. Updated interactive-search route to fetch and pass enabled indexer IDs
5. Added validation: search fails if no indexers are configured/enabled
6. Updated documentation to reflect indexer filtering behavior

**Impact:**
- Manual search: Only searches enabled indexers
- Interactive search: Only searches enabled indexers
- RSS monitoring: Already correctly filtered (no changes needed)

**Testing:** TypeScript type checking passed with no errors