### PR TITLE
Add Unraid Template to show in Unraid Community Apps (CA Store)

### DIFF
--- a/unraid.xml
+++ b/unraid.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<Container version="2">
+  <Name>ReadMeABook</Name>
+  <Repository>ghcr.io/kikootwo/readmeabook:latest</Repository>
+  <Registry>https://github.com/kikootwo/ReadMeABook/pkgs/container/readmeabook</Registry>
+  <TemplateURL>https://github.com/kikootwo/ReadMeABook/blob/main/unraid.xml</TemplateURL>
+  <MyIP/>
+  <Shell>bash</Shell>
+  <Privileged>false</Privileged>
+  <Support>https://github.com/kikootwo/ReadMeABook/issues</Support>
+  <Discord>https://discord.gg/kaw6jKbKts</Discord>
+  <Project>https://github.com/kikootwo/ReadMeABook</Project>
+  <Overview>ReadMeABook is an audiobook library management and automation system, purpose-built for audiobooks. Request a book, and it handles the rest: searches indexers, downloads, organizes files, and triggers a library scan.</Overview>
+  <Category>Downloaders: Tools: MediaApp:Other MediaServer:Books</Category>
+  <WebUI>http://[IP]:[PORT: 3030]/</WebUI>
+  <Icon>https://raw.githubusercontent.com/kikootwo/ReadMeABook/main/public/RMAB_1024x1024_APPICON.png</Icon>
+  <ExtraParams>--restart=unless-stopped</ExtraParams>
+  <PostArgs/>
+  <CPUset/>
+  <DateInstalled/>
+  <Maintainer>
+    <WebPage>https://github.com/kikootwo</WebPage>
+    <DonateText>If you find this project useful, consider supporting development!</DonateText>
+    <DonateLink>https://github.com/sponsors/kikootwo</DonateLink>
+  </Maintainer>
+  <Requires/>
+  <Screenshots>
+    <Screenshot>https://raw.githubusercontent.com/kikootwo/ReadMeABook/main/screenshots/HOMEPAGE.png</Screenshot>
+    <Screenshot>https://raw.githubusercontent.com/kikootwo/ReadMeABook/main/screenshots/ADMIN.png</Screenshot>
+    <Screenshot>https://raw.githubusercontent.com/kikootwo/ReadMeABook/main/screenshots/BOOKDATE.png</Screenshot>
+  </Screenshots>
+  <Network>bridge</Network>
+  <Config Name="Web UI Host Port" Target="3030" Default="3030" Mode="tcp" Description="Port for ReadMeABook's web interface." Type="Port" Display="always" Required="true" Mask="false">3030</Config>
+  <Config Name="Appdata" Target="/app/config" Default="/mnt/user/appdata/readmeabook" Mode="rw" Description="Persistent config files" Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/readmeabook</Config>
+  <Config Name="Download Location" Target="/downloads" Default="/mnt/user/data/downloads" Mode="rw" Description="Both your download client and RMAB must see files at the SAME path. See: https://github.com/kikootwo/ReadMeABook/blob/main/documentation/deployment/volume-mapping.md" Type="Path" Display="always" Required="true" Mask="false"/>
+  <Config Name="Media Library" Target="/media" Default="/mnt/user/data/media/audiobooks" Mode="rw" Description="Your audiobook/ebook library" Type="Path" Display="always" Required="true" Mask="false"/>
+  <Config Name="Postgres Storage Location" Target="/var/lib/postgresql/data" Default="readmeabook_pgdata" Mode="rw" Description="" Type="Path" Display="always" Required="true" Mask="false">readmeabook_pgdata</Config>
+  <Config Name="Redis Storage Location" Target="/var/lib/redis" Default="/mnt/user/appdata/readmeabook/redis" Mode="rw" Description="" Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/readmeabook/redis</Config>
+  <Config Name="App Cache" Target="/app/cache" Default="/mnt/user/appdata/readmeabook/cache" Mode="rw" Description="" Type="Path" Display="advanced" Required="true" Mask="false">/mnt/user/appdata/readmeabook/cache</Config>
+  <Config Name="PUBLIC_URL" Target="PUBLIC_URL" Default="https://audiobooks.example.com" Mode="" Description="Public URL if accessing from outside localhost. Required for OAuth." Type="Variable" Display="always" Required="false" Mask="false"/>
+  <Config Name="PUID" Target="PUID" Default="99" Mode="" Description="" Type="Variable" Display="advanced-hide" Required="true" Mask="false">99</Config>
+  <Config Name="PGID" Target="PGID" Default="100" Mode="" Description="" Type="Variable" Display="advanced-hide" Required="true" Mask="false">100</Config>
+  <TailscaleStateDir/>
+</Container>


### PR DESCRIPTION
### Description

This PR adds a `unraid.xml` template file to the root of the repository, which, when added to the [Unraid](https://unraid.net/) ["Community Applications" (CA) store](https://unraid.net/community/apps#community-apps-iframe), allows easy container installation for Unraid users (generally, the "default" way Unraid handles Docker and containers).

This template allows Unraid users to install the ReadMeABook "unified" (AIO) container directly from the CA store with minimal setup (prefills the necessary ports, volume mappings, and environment variables recommended in the compose). Having it alongside your application code and in this repo makes it easy to change any container-related items and keep it correct/compatible with your latest release.

#### Discussion / Questions Ahead of Merging

I ran into permissions issues relating to the `pgdata` folder when creating the template, specifically, using a bind mount resulted in `Operation not permitted`. However, using a named volume does work without issue, though I think for most users this wouldn't be preferred as backups, etc., become much more difficult (for context, many Unraid users simply use a tool that backs up all "appdata" directories).

Unraid's standard user (`PUID`) and group (`PGID`) are `99` and `100`, respectively. Using bind mounts, there's an issue when `initdb` attempts to perform a permission change / file operation. Following the advice in the [entrypoint script](https://github.com/kikootwo/ReadMeABook/blob/main/docker/unified/entrypoint.sh#L179), named volumes work without issue. Do others have a better route here?

#### Additional Maintainer Steps

In order for this to be available in the CA Store, you need to apply to have it added via a [Community Applications submission form](https://form.asana.com/?k=qtIUrf5ydiXvXzPI57BiJw&d=714739274360802). This form is very short and self-explanatory. Usually, a repo is approved within 24-48 hours, though that, too, is a manual process. **Despite what it says, you shouldn't need to create a forum thread (there are links to your support outlets as part of the template.**

Once accepted, the CA scraper checks the repo frequently for updates (I think it's about every 2 hours).

Alternatively, if you prefer not to maintain Unraid-specific files or don't want to deal with the submission process (since I saw in Discord you don't use Unraid), I maintain a dedicated templates repository ([tritones/unraid-templates](https://github.com/tritones/unraid-templates)) that is already published in the store. If you want to go this route we'd close this PR and open one in my repo.

#### Links and Helpful Info

If you want to understand what this file does or how the formatting works:

- [Submission Process (official docs)](https://docs.unraid.net/unraid-os/using-unraid-to/run-docker-containers/community-applications/#contributing-your-own-applications)
- [Writing a template compatible for Unraid - Selfhosters.net](https://selfhosters.net/docker/templating/templating/)
- [Unraid Forum about XML Schema](https://forums.unraid.net/topic/38619-docker-template-xml-schema/)
- [Unraid Forum about Docker FAQ & XML Syntax](https://forums.unraid.net/topic/57181-real-docker-faq/#comment-566084)