### PR TITLE
Update Unriad Template to fix permissions and fix `WebUI` link

### DIFF
--- a/unraid.xml
+++ b/unraid.xml
@@ -12,7 +12,7 @@
   <Project>https://github.com/kikootwo/ReadMeABook</Project>
   <Overview>ReadMeABook is an audiobook library management and automation system, purpose-built for audiobooks. Request a book, and it handles the rest: searches indexers, downloads, organizes files, and triggers a library scan.</Overview>
   <Category>Downloaders: Tools: MediaApp:Other MediaServer:Books</Category>
-  <WebUI>http://[IP]:[PORT: 3030]/</WebUI>
+  <WebUI>http://[IP]:[PORT:3030]/</WebUI>
   <Icon>https://raw.githubusercontent.com/kikootwo/ReadMeABook/main/public/RMAB_1024x1024_APPICON.png</Icon>
   <ExtraParams>--restart=unless-stopped</ExtraParams>
   <PostArgs/>
@@ -31,10 +31,10 @@
   </Screenshots>
   <Network>bridge</Network>
   <Config Name="Web UI Host Port" Target="3030" Default="3030" Mode="tcp" Description="Port for ReadMeABook's web interface." Type="Port" Display="always" Required="true" Mask="false">3030</Config>
-  <Config Name="Appdata" Target="/app/config" Default="/mnt/user/appdata/readmeabook" Mode="rw" Description="Persistent config files" Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/readmeabook</Config>
+  <Config Name="Config Location" Target="/app/config" Default="/mnt/user/appdata/readmeabook/config" Mode="rw" Description="Persistent config files" Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/readmeabook/config</Config>
   <Config Name="Download Location" Target="/downloads" Default="/mnt/user/data/downloads" Mode="rw" Description="Both your download client and RMAB must see files at the SAME path. See: https://github.com/kikootwo/ReadMeABook/blob/main/documentation/deployment/volume-mapping.md" Type="Path" Display="always" Required="true" Mask="false"/>
   <Config Name="Media Library" Target="/media" Default="/mnt/user/data/media/audiobooks" Mode="rw" Description="Your audiobook/ebook library" Type="Path" Display="always" Required="true" Mask="false"/>
-  <Config Name="Postgres Storage Location" Target="/var/lib/postgresql/data" Default="readmeabook_pgdata" Mode="rw" Description="" Type="Path" Display="always" Required="true" Mask="false">readmeabook_pgdata</Config>
+  <Config Name="Postgres Storage Location" Target="/var/lib/postgresql/data" Default="/mnt/user/appdata/readmeabook/pgdata" Mode="rw" Description="" Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/readmeabook/pgdata</Config>
   <Config Name="Redis Storage Location" Target="/var/lib/redis" Default="/mnt/user/appdata/readmeabook/redis" Mode="rw" Description="" Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/readmeabook/redis</Config>
   <Config Name="App Cache" Target="/app/cache" Default="/mnt/user/appdata/readmeabook/cache" Mode="rw" Description="" Type="Path" Display="advanced" Required="true" Mask="false">/mnt/user/appdata/readmeabook/cache</Config>
   <Config Name="PUBLIC_URL" Target="PUBLIC_URL" Default="https://audiobooks.example.com" Mode="" Description="Public URL if accessing from outside localhost. Required for OAuth." Type="Variable" Display="always" Required="false" Mask="false"/>


### PR DESCRIPTION
### Description

This PR fixes the "WebUI" link so that it actually links to the correct port (there was a typo with a preceding space: ` 3030`). This also fixes permission issues with the Postgres data folder (`pgdata`), which was mentioned in the original PR: https://github.com/kikootwo/ReadMeABook/pull/53.

Now, standard bind mounts are usable on Unraid instead of named volumes. This fix was courtesy of Discord users who correctly pointed out that having the `config` folder as a parent to the `pgdata` folder caused conflicts with permission settings, which makes sense given the steps in `entrypoint.sh`. 

The new setup works out of the box on my Unraid machine and should be more in line with the repo's recommended Docker Compose file. Ideally, this resolves any outstanding permission issues/concerns.

---

As stated in the first PR, once merged, this should reflect in the Unraid "Community Applications" (CA) store soon after its next repository scan, which should occur at least daily (I believe it's every 2 hours).