### PR TITLE
Extend the default timeout to add a torrent (Qbit, Transmission, Deluge)

### DIFF
--- a/src/lib/integrations/deluge.service.ts
+++ b/src/lib/integrations/deluge.service.ts
@@ -49,7 +49,7 @@ export class DelugeService implements IDownloadClient {
       ? new https.Agent({ rejectUnauthorized: false }) : undefined;
     if (httpsAgent) logger.info('[Deluge] SSL certificate verification disabled');
 
-    this.client = axios.create({ baseURL: this.baseUrl, timeout: 30000, httpsAgent });
+    this.client = axios.create({ baseURL: this.baseUrl, timeout: 60000, httpsAgent }); // 60 seconds - some indexers (e.g. yggtorrent) enforce a 30s wait before download
   }
 
   /** JSON-RPC call with automatic re-authentication on auth failure */
@@ -190,7 +190,7 @@ export class DelugeService implements IDownloadClient {
     try {
       torrentResponse = await axios.get(torrentUrl, {
         responseType: 'arraybuffer', maxRedirects: 0,
-        validateStatus: (s) => s >= 200 && s < 300, timeout: 30000,
+        validateStatus: (s) => s >= 200 && s < 300, timeout: 60000, // 60 seconds - some indexers (e.g. yggtorrent) enforce a 30s wait before download
       });
       if (torrentResponse.data.length > 0) {
         const magnetMatch = torrentResponse.data.toString().match(/^magnet:\?[^\s]+$/);
@@ -203,7 +203,7 @@ export class DelugeService implements IDownloadClient {
         const loc = error.response.headers['location'];
         if (loc?.startsWith('magnet:')) return this.addMagnetLink(loc, category, options);
         if (loc?.startsWith('http://') || loc?.startsWith('https://')) {
-          try { torrentResponse = await axios.get(loc, { responseType: 'arraybuffer', timeout: 30000, maxRedirects: 5 }); }
+          try { torrentResponse = await axios.get(loc, { responseType: 'arraybuffer', timeout: 60000, maxRedirects: 5 }); } // 60 seconds - some indexers (e.g. yggtorrent) enforce a 30s wait before download
           catch { throw new Error('Failed to download torrent file after redirect'); }
         } else { throw new Error(`Invalid redirect location: ${loc}`); }
       } else { throw new Error(`Failed to download torrent: HTTP ${status}`); }

--- a/src/lib/integrations/qbittorrent.service.ts
+++ b/src/lib/integrations/qbittorrent.service.ts
@@ -140,7 +140,7 @@ export class QBittorrentService implements IDownloadClient {
 
     this.client = axios.create({
       baseURL: `${this.baseUrl}/api/v2`,
-      timeout: 30000,
+      timeout: 60000, // 60 seconds - some indexers (e.g. yggtorrent) enforce a 30s wait before download
       httpsAgent: this.httpsAgent,
       // Support nginx/Apache reverse proxy with HTTP Basic Auth
       auth: {
@@ -352,7 +352,7 @@ export class QBittorrentService implements IDownloadClient {
         responseType: 'arraybuffer',
         maxRedirects: 0,
         validateStatus: (status) => status >= 200 && status < 300, // Only 2xx is success
-        timeout: 30000, // 30 seconds - public indexers can be slow
+        timeout: 60000, // 60 seconds - some indexers (e.g. yggtorrent) enforce a 30s wait before download
       });
 
       logger.info(` Got 2xx response, size=${torrentResponse.data.length} bytes`);
@@ -394,7 +394,7 @@ export class QBittorrentService implements IDownloadClient {
           try {
             torrentResponse = await axios.get(location, {
               responseType: 'arraybuffer',
-              timeout: 30000,
+              timeout: 60000, // 60 seconds - some indexers (e.g. yggtorrent) enforce a 30s wait before download
               maxRedirects: 5,
             });
             logger.info(` After following redirect: size=${torrentResponse.data.length} bytes`);

--- a/src/lib/integrations/transmission.service.ts
+++ b/src/lib/integrations/transmission.service.ts
@@ -106,7 +106,7 @@ export class TransmissionService implements IDownloadClient {
 
     this.client = axios.create({
       baseURL: this.baseUrl,
-      timeout: 30000,
+      timeout: 60000, // 60 seconds - some indexers (e.g. yggtorrent) enforce a 30s wait before download
       httpsAgent: this.httpsAgent,
     });
   }
@@ -274,7 +274,7 @@ export class TransmissionService implements IDownloadClient {
         responseType: 'arraybuffer',
         maxRedirects: 0,
         validateStatus: (status) => status >= 200 && status < 300,
-        timeout: 30000,
+        timeout: 60000, // 60 seconds - some indexers (e.g. yggtorrent) enforce a 30s wait before download
       });
 
       // Check if response body is a magnet link
@@ -302,7 +302,7 @@ export class TransmissionService implements IDownloadClient {
           try {
             torrentResponse = await axios.get(location, {
               responseType: 'arraybuffer',
-              timeout: 30000,
+              timeout: 60000, // 60 seconds - some indexers (e.g. yggtorrent) enforce a 30s wait before download
               maxRedirects: 5,
             });
           } catch {


### PR DESCRIPTION
Hi, 
I already discuss of this subject on the discord. And the maintener was pretty fast and attentive to the issue.

Some Indexers (like YGG torrent) require to wait 30 seconds before allow to download the .torrent file.
And by a coincidence it's also the exact max value to the timeout from the differents downloader (Qbit, transmission and now Deluge) So the download failed each time because we don't enouth time to catch the .torrent. 

Kikootwo already change the value in prowlarr.service.ts to pass by 60 seconds but this modify doesn't work.
It works only if the modify in the service.ts file on each downloader.

Here the result with default timeout in the downloader (30 sec, test with transmission )
<img width="957" height="222" alt="Capture d&#39;écran 2026-02-21 134134" src="https://github.com/user-attachments/assets/7b687e52-4fe3-410f-921b-46daecc14089" />

And when i changed the timeout to pass to 60 seconds in transmission.service.ts and retry to do a manual search :
<img width="1000" height="261" alt="Capture d&#39;écran 2026-02-21 133908" src="https://github.com/user-attachments/assets/de30d174-2fb6-4692-8eab-dcad532ae89d" />




