### PR TITLE
feat(audiobook): add language, format and publisher to details modal

### DIFF
--- a/src/components/audiobooks/AudiobookDetailsModal.tsx
+++ b/src/components/audiobooks/AudiobookDetailsModal.tsx
@@ -548,6 +548,30 @@ export function AudiobookDetailsModal({
                     </a>
                   </div>
 
+                  {/* Language */}
+                  {audiobook.language && (
+                    <div>
+                      <p className="text-gray-500 dark:text-gray-400">Language</p>
+                      <p className="text-gray-900 dark:text-gray-100">{audiobook.language.charAt(0).toUpperCase() + audiobook.language.slice(1)}</p>
+                    </div>
+                  )}
+
+                  {/* Format */}
+                  {audiobook.formatType && (
+                    <div>
+                      <p className="text-gray-500 dark:text-gray-400">Format</p>
+                      <p className="text-gray-900 dark:text-gray-100">{audiobook.formatType.charAt(0).toUpperCase() + audiobook.formatType.slice(1)}</p>
+                    </div>
+                  )}
+
+                  {/* Publisher */}
+                  {audiobook.publisherName && (
+                    <div>
+                      <p className="text-gray-500 dark:text-gray-400">Publisher</p>
+                      <p className="text-gray-900 dark:text-gray-100">{audiobook.publisherName}</p>
+                    </div>
+                  )}
+
                   {/* Download Link - subtle utility, visible from any context */}
                   {isAvailable && downloadAvailable && requestId && user?.permissions?.download !== false && (
                     <div>

--- a/src/lib/hooks/useAudiobooks.ts
+++ b/src/lib/hooks/useAudiobooks.ts
@@ -34,6 +34,9 @@ export interface Audiobook {
   requestedByUsername?: string | null;  // Username who requested (only if not current user)
   hasReportedIssue?: boolean;  // True if an open issue exists for this audiobook
   isIgnored?: boolean;  // True if this user has ignored this audiobook from auto-requests
+  language?: string;
+  formatType?: string;
+  publisherName?: string;
 }
 
 export function useAudiobooks(type: 'popular' | 'new-releases', limit: number = 20, page: number = 1, hideAvailable: boolean = false) {

--- a/src/lib/integrations/audible.service.ts
+++ b/src/lib/integrations/audible.service.ts
@@ -50,6 +50,9 @@ export interface AudibleAudiobook {
   series?: string;
   seriesPart?: string;
   seriesAsin?: string;
+  language?: string;
+  formatType?: string;
+  publisherName?: string;
 }
 
 export interface AudibleSearchResult {
@@ -774,6 +777,9 @@ export class AudibleService {
         series: data.seriesPrimary?.name || undefined,
         seriesPart: data.seriesPrimary?.position || undefined,
         seriesAsin: data.seriesPrimary?.asin || undefined,
+        language: data.language || undefined,
+        formatType: data.formatType || undefined,
+        publisherName: data.publisherName || undefined,
       };
 
       // Ensure cover art URL is high quality


### PR DESCRIPTION
# Summary
A small PR to add information about the language, format and publisher in detail modal.
Especially if you're not looking for English books, it's helpful to see the language listed, even if you can figure it out from the description

# Screenshot
<img width="528" height="208" alt="image" src="https://github.com/user-attachments/assets/4225f6d5-493e-4fa3-a893-e66bab2250a4" />
