### PR TITLE
feat: add On Grab notification event

### DIFF
--- a/documentation/backend/services/notifications.md
+++ b/documentation/backend/services/notifications.md
@@ -7,7 +7,7 @@ Sends notifications for audiobook request events (pending approval, approved, av
 
 ## Key Details
 - **Backends:** Apprise (API), Discord (webhooks), ntfy (API), Pushover (API)
-- **Events:** request_pending_approval, request_approved, request_available, request_error, issue_reported
+- **Events:** request_pending_approval, request_approved, request_grabbed, request_available, request_error, issue_reported
 - **Encryption:** AES-256-GCM for sensitive config (webhook URLs, API keys, notification URLs)
 - **Delivery:** Async via Bull job queue (priority 5)
 - **Failure Handling:** Non-blocking, Promise.allSettled (one backend fails, others succeed)
@@ -33,11 +33,14 @@ model NotificationBackend {
 |-------|---------|------------------------|
 | request_pending_approval | User creates request | Request needs admin approval |
 | request_approved | Admin approves OR auto-approval | Request approved (manual or auto) |
+| request_grabbed | Torrent/NZB added to download client | Download handed off to configured download client (title resolves by type) |
 | request_available | Plex/ABS scan or ebook download completes | Request available (title resolves by type) |
 | request_error | Download/import fails | Request failed at any stage |
 | issue_reported | User reports issue | User reports problem with available audiobook |
 
 **Dynamic Titles:** Events can define `titleByRequestType` in `notification-events.ts` for type-specific titles.
+- `request_grabbed` + `requestType: 'audiobook'` → "Audiobook Grabbed"
+- `request_grabbed` + `requestType: 'ebook'` → "Ebook Grabbed"
 - `request_available` + `requestType: 'audiobook'` → "Audiobook Available"
 - `request_available` + `requestType: 'ebook'` → "Ebook Available"
 - `request_available` + no requestType → "Request Available" (fallback)
@@ -65,6 +68,11 @@ model NotificationBackend {
 **Admin Approval (POST /api/admin/requests/[id]/approve)**
 - Approve (with or without pre-selected torrent): After job triggered → request_approved
 - Deny: No notification
+
+**Download Grabbed (processor: download-torrent)**
+- After `client.addDownload()` succeeds and `DownloadHistory` record created → request_grabbed
+- `message` field: `"${torrent.title} via ${indexer} (${clientType})"`
+- `requestType`: from `request.type` (audiobook/ebook)
 
 **Audiobook Available (processors: scan-plex, plex-recently-added)**
 - After `status: 'available'` update → request_available (requestType: 'audiobook')

--- a/src/lib/constants/notification-events.ts
+++ b/src/lib/constants/notification-events.ts
@@ -19,6 +19,7 @@ export type NotificationPriority = 'normal' | 'high';
  * - `emoji`:              Emoji prefix for notification titles
  * - `severity`:           Drives provider formatting (colors, Apprise types, ntfy tags)
  * - `priority`:           Drives notification urgency (Pushover/ntfy priority levels)
+ * - `messageLabel`:       Optional label for the `message` payload field (defaults to "Error" if omitted)
  */
 export const NOTIFICATION_EVENTS = {
   request_pending_approval: {
@@ -34,6 +35,18 @@ export const NOTIFICATION_EVENTS = {
     emoji: '\u2705',
     severity: 'success' as const,
     priority: 'normal' as const,
+  },
+  request_grabbed: {
+    label: 'Request Grabbed',
+    title: 'Download Grabbed',
+    titleByRequestType: {
+      audiobook: 'Audiobook Grabbed',
+      ebook: 'Ebook Grabbed',
+    } as Record<string, string>,
+    emoji: '\u{1F4E5}',
+    severity: 'info' as const,
+    priority: 'normal' as const,
+    messageLabel: 'Details',
   },
   request_available: {
     label: 'Request Available',
@@ -59,6 +72,7 @@ export const NOTIFICATION_EVENTS = {
     emoji: '\u{1F6A9}',
     severity: 'warning' as const,
     priority: 'high' as const,
+    messageLabel: 'Reason',
   },
 } as const;
 
@@ -71,9 +85,24 @@ export const NOTIFICATION_EVENT_KEYS = Object.keys(NOTIFICATION_EVENTS) as [Noti
 /** Metadata shape for a single notification event */
 export type NotificationEventMeta = (typeof NOTIFICATION_EVENTS)[NotificationEvent];
 
+/**
+ * Normalized interface for event metadata consumed by providers.
+ * Broadens the `as const` literal union to make optional fields accessible.
+ */
+export interface NotificationEventConfig {
+  label: string;
+  title: string;
+  titleByRequestType?: Record<string, string>;
+  emoji: string;
+  severity: NotificationSeverity;
+  priority: NotificationPriority;
+  /** Label for the `message` payload field. Defaults to "Error" in providers when absent. */
+  messageLabel?: string;
+}
+
 /** Helper: get event metadata by key */
-export function getEventMeta(event: NotificationEvent) {
-  return NOTIFICATION_EVENTS[event];
+export function getEventMeta(event: NotificationEvent): NotificationEventConfig {
+  return NOTIFICATION_EVENTS[event] as NotificationEventConfig;
 }
 
 /**

--- a/src/lib/processors/download-torrent.processor.ts
+++ b/src/lib/processors/download-torrent.processor.ts
@@ -103,8 +103,32 @@ export async function processDownloadTorrent(payload: DownloadTorrentPayload): P
 
     logger.info(`Created download history record: ${downloadHistory.id}`);
 
-    // Trigger monitor download job with initial delay
+    // Send grab notification
+    const requestWithUser = await prisma.request.findUnique({
+      where: { id: requestId },
+      include: {
+        user: { select: { plexUsername: true } },
+      },
+    });
+
     const jobQueue = getJobQueueService();
+
+    if (requestWithUser) {
+      const grabMessage = `${torrent.title} via ${torrent.indexer} (${client.clientType})`;
+      await jobQueue.addNotificationJob(
+        'request_grabbed',
+        requestId,
+        audiobook.title,
+        audiobook.author,
+        requestWithUser.user.plexUsername || 'Unknown User',
+        grabMessage,
+        requestWithUser.type
+      ).catch((error) => {
+        logger.error('Failed to queue grab notification', { error: error instanceof Error ? error.message : String(error) });
+      });
+    }
+
+    // Trigger monitor download job with initial delay
     await jobQueue.addMonitorJob(
       requestId,
       downloadHistory.id,

--- a/src/lib/services/notification/providers/apprise.provider.ts
+++ b/src/lib/services/notification/providers/apprise.provider.ts
@@ -127,6 +127,7 @@ export class AppriseProvider implements INotificationProvider {
 
   private formatMessage(payload: NotificationPayload): { title: string; body: string } {
     const { event, title, author, userName, message, requestType } = payload;
+    const meta = getEventMeta(event);
 
     const isIssue = event === 'issue_reported';
     const messageLines = [
@@ -136,7 +137,9 @@ export class AppriseProvider implements INotificationProvider {
     ];
 
     if (message) {
-      messageLines.push(isIssue ? `\u{1F4DD} Reason: ${message}` : `\u26A0\uFE0F Error: ${message}`);
+      const messageLabel = meta.messageLabel ?? 'Error';
+      const msgEmoji = meta.severity === 'error' ? '\u26A0\uFE0F' : '\u{1F4DD}';
+      messageLines.push(`${msgEmoji} ${messageLabel}: ${message}`);
     }
 
     return {

--- a/src/lib/services/notification/providers/discord.provider.ts
+++ b/src/lib/services/notification/providers/discord.provider.ts
@@ -71,7 +71,7 @@ export class DiscordProvider implements INotificationProvider {
     ];
 
     if (message) {
-      fields.push({ name: isIssue ? 'Reason' : 'Error', value: message, inline: false });
+      fields.push({ name: meta.messageLabel ?? 'Error', value: message, inline: false });
     }
 
     return {

--- a/src/lib/services/notification/providers/ntfy.provider.ts
+++ b/src/lib/services/notification/providers/ntfy.provider.ts
@@ -84,6 +84,7 @@ export class NtfyProvider implements INotificationProvider {
 
   private formatMessage(payload: NotificationPayload): { title: string; message: string } {
     const { event, title, author, userName, message, requestType } = payload;
+    const meta = getEventMeta(event);
 
     const isIssue = event === 'issue_reported';
     const messageLines = [
@@ -93,7 +94,9 @@ export class NtfyProvider implements INotificationProvider {
     ];
 
     if (message) {
-      messageLines.push(isIssue ? `\u{1F4DD} Reason: ${message}` : `\u26A0\uFE0F Error: ${message}`);
+      const messageLabel = meta.messageLabel ?? 'Error';
+      const msgEmoji = meta.severity === 'error' ? '\u26A0\uFE0F' : '\u{1F4DD}';
+      messageLines.push(`${msgEmoji} ${messageLabel}: ${message}`);
     }
 
     return {

--- a/src/lib/services/notification/providers/pushover.provider.ts
+++ b/src/lib/services/notification/providers/pushover.provider.ts
@@ -91,7 +91,9 @@ export class PushoverProvider implements INotificationProvider {
     ];
 
     if (message) {
-      messageLines.push('', isIssue ? `\u{1F4DD} Reason: ${message}` : `\u26A0\uFE0F Error: ${message}`);
+      const messageLabel = meta.messageLabel ?? 'Error';
+      const msgEmoji = meta.severity === 'error' ? '\u26A0\uFE0F' : '\u{1F4DD}';
+      messageLines.push('', `${msgEmoji} ${messageLabel}: ${message}`);
     }
 
     return {


### PR DESCRIPTION
# Summary

Adds a new `request_grabbed` notification event that fires when a torrent or NZB is successfully handed off to the configured download client; the RMAB equivalent of Sonarr/Radarr's "On Grab" notification. Previously, no notification fired at the actual grab moment. Addresses #161 

---

## Background & Motivation

RMAB already had five notification events:

| Event | When it fires |
|---|---|
| `request_pending_approval` | Request created, needs admin approval |
| `request_approved` | Request approved (manual or auto) |
| `request_available` | Book fully imported and ready |
| `request_error` | Download or import failed |
| `issue_reported` | User reports a problem with an available book |

**The gap:** `request_approved` is not the same as "on grab." A request can be approved while still waiting for a search result (status `awaiting_search` or `pending`). The actual grab — the moment the torrent/NZB file is sent to the configured download client — happened silently with no notification.

This PR adds `request_grabbed`, which fires from inside `download-torrent.processor.ts` immediately after `client.addDownload()` succeeds and the `DownloadHistory` record is created. At that point the download client has definitively accepted the file.

---

## Changes

### 1. `src/lib/constants/notification-events.ts`

- Added `request_grabbed` to `NOTIFICATION_EVENTS` with:
  - `titleByRequestType`: resolves to "Audiobook Grabbed" or "Ebook Grabbed" depending on request type
  - `severity: 'info'`, `priority: 'normal'`
  - `messageLabel: 'Details'` (see item 2 below)
- Added `messageLabel: 'Reason'` to the existing `issue_reported` event (see item 2)
- Added new `NotificationEventConfig` interface — a normalized, provider-facing type that broadens the `as const` literal union and explicitly declares `messageLabel?: string` as an optional field
- Updated `getEventMeta()` return type from the raw inferred union to `NotificationEventConfig`, resolving TypeScript errors in all providers that access `messageLabel`

### 2. `src/lib/services/notification/providers/` — all 4 providers

**Root cause fixed:** All four providers (Discord, ntfy, Pushover, Apprise) had hardcoded logic for labeling the `message` payload field:

```
// Before (all providers)
isIssue ? 'Reason' : 'Error'
```

This meant any future event that used the `message` field for non-error context — including `request_grabbed` — would have its content displayed under an "⚠️ Error:" label, which isn't exactly accurate.

**Fix applied consistently across all providers:**

```typescript
// After (all providers)
const messageLabel = meta.messageLabel ?? 'Error';
const msgEmoji = meta.severity === 'error' ? '⚠️' : '📝';
// used as: `${msgEmoji} ${messageLabel}: ${message}`
```

The label and emoji now derive from event metadata:
- `request_error` → no `messageLabel` → defaults to `⚠️ Error:`
- `issue_reported` → `messageLabel: 'Reason'` → renders as `📝 Reason:`
- `request_grabbed` → `messageLabel: 'Details'` → renders as `📝 Details:`

**Per-provider changes:**
- **Discord** (`discord.provider.ts`): embed field name changed from `isIssue ? 'Reason' : 'Error'` to `meta.messageLabel ?? 'Error'`
- **ntfy** (`ntfy.provider.ts`): added `const meta = getEventMeta(event)` inside `formatMessage`; replaced hardcoded label with `meta.messageLabel ?? 'Error'` + severity-driven emoji
- **Pushover** (`pushover.provider.ts`): `meta` was already in scope; replaced hardcoded label with `meta.messageLabel ?? 'Error'` + severity-driven emoji
- **Apprise** (`apprise.provider.ts`): added `const meta = getEventMeta(event)` inside `formatMessage`; replaced hardcoded label with `meta.messageLabel ?? 'Error'` + severity-driven emoji

### 3. `src/lib/processors/download-torrent.processor.ts`

Added grab notification trigger after the `DownloadHistory` record is created (i.e., after `client.addDownload()` has confirmed success):

- Fetches `request.user.plexUsername` for the notification (same DB-lookup pattern used in `monitor-download.processor.ts`)
- Queues `request_grabbed` via `jobQueue.addNotificationJob()`
- `message` field carries: `"<torrent title> via <indexer> (<clientType>)"` — gives recipients full context on what was grabbed and from where
- `requestType` is read from `request.type` (the actual DB value) rather than inferred from protocol, ensuring correct title resolution for ebooks vs audiobooks

### 4. `documentation/backend/services/notifications.md`

- Updated events list and event types table to include `request_grabbed`
- Added `request_grabbed` `titleByRequestType` examples to the Dynamic Titles section
- Added "Download Grabbed" trigger block to the Notification Triggers section describing the exact fire point and message format

---

## What the Grab Notification Looks Like

For a grab of an audiobook torrent, the notification payload resolves to:

| Field | Value |
|---|---|
| Title | Audiobook Grabbed |
| Book | The Name of the Wind |
| Author | Patrick Rothfuss |
| Requested By | user |
| Details | The Name of the Wind [M4B/192kbps] via NZBGeek (SABnzbd) |

This follows the same structure as all other RMAB notifications — book title, author, requesting user, and an optional labeled message field. The `message` field here carries torrent/indexer details the same way `request_error` carries error text and `issue_reported` carries the user's reason.

---

## Provider Compatibility

`request_grabbed` is included in `NOTIFICATION_EVENTS` and will appear as a subscribable checkbox in the notification backend settings UI for **all four providers** automatically — no UI changes required. The event is delivered through the same async Bull job queue as all other events.

| Provider | Selectable | Delivered | Message field label |
|---|---|---|---|
| Discord | ✅ | ✅ | "Details" (embed field name) |
| ntfy | ✅ | ✅ | 📝 Details: (message body) |
| Pushover | ✅ | ✅ | 📝 Details: (message body) |
| Apprise | ✅ | ✅ | 📝 Details: (message body) |

---

## Tested on my UnRaid instance, screenshots here:

<img width="485" height="356" alt="image" src="https://github.com/user-attachments/assets/d67e38c4-8120-46f3-809f-41b05ef1ddc6" />

<img width="234" height="315" alt="image" src="https://github.com/user-attachments/assets/f6802b9c-053a-48d6-abd4-8ef18a4d6d32" />

---

## AI Disclosure

Claude Sonnet 4.6 was used to develop this PR, I did not see any specific no AI use language for this project but apologies if I overlooked something!