### PR TITLE
Add SWAG reverse proxy subdomain conf sample

### DIFF
--- a/documentation/deployment/readmeabook.subdomain.conf.sample
+++ b/documentation/deployment/readmeabook.subdomain.conf.sample
@@ -1,0 +1,32 @@
+## Version 2026/03/27
+# make sure that your readmeabook container is named readmeabook
+# make sure that your dns has a cname set for readmeabook
+# readmeabook has built-in authentication (local accounts, Plex OAuth, OIDC)
+# do not add an external auth layer (Authelia, Authentik, etc.) -- it will conflict with built-in auth
+# set the PUBLIC_URL environment variable on the readmeabook container to your full public HTTPS URL
+# (e.g. PUBLIC_URL=https://readmeabook.yourdomain.com) -- required for Plex OAuth and OIDC callbacks
+# websocket support required for Next.js is handled automatically by SWAG's proxy.conf
+
+server {
+    listen 443 ssl;
+#    listen 443 quic;
+    listen [::]:443 ssl;
+#    listen [::]:443 quic;
+
+    server_name readmeabook.*;
+
+    include /config/nginx/ssl.conf;
+
+    client_max_body_size 0;
+
+    location / {
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app readmeabook;
+        set $upstream_port 3030;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+    }
+
+}


### PR DESCRIPTION
## Summary

- Adds `documentation/deployment/readmeabook.subdomain.conf.sample` — a SWAG (linuxserver Secure Web Application Gateway) nginx reverse proxy conf for readmeabook
- Follows SWAG's contribution guidelines and naming conventions
- Subdomain-only (no subfolder conf — Next.js with no `basePath` configured doesn't support subfolder deployment)
- No external auth stubs (readmeabook has built-in JWT, Plex OAuth, and OIDC auth; layering Authelia/Authentik on top would conflict)
- Includes notes on `PUBLIC_URL` requirement for OAuth callbacks and WebSocket handling via SWAG's `proxy.conf`

## Usage

1. Copy `readmeabook.subdomain.conf.sample` to your SWAG container at `/config/nginx/proxy-confs/readmeabook.subdomain.conf`
2. Set `PUBLIC_URL=https://readmeabook.yourdomain.com` on the readmeabook container
3. Ensure both containers are on the same Docker bridge network
4. Add a DNS CNAME for `readmeabook` pointing to your SWAG host

## Notes

This conf is intended to be submitted upstream to [linuxserver/reverse-proxy-confs](https://github.com/linuxserver/reverse-proxy-confs) once validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)