### PR TITLE
Added ability to toggle post-download organization on/off

### DIFF
--- a/src/app/admin/settings/lib/types.ts
+++ b/src/app/admin/settings/lib/types.ts
@@ -96,6 +96,7 @@ export interface DownloadClientSettings {
 export interface PathsSettings {
   downloadDir: string;
   mediaDir: string;
+  autoOrganizeEnabled: boolean;
   audiobookPathTemplate?: string;
   ebookPathTemplate?: string;
   metadataTaggingEnabled: boolean;

--- a/src/app/admin/settings/tabs/PathsTab/PathsTab.tsx
+++ b/src/app/admin/settings/tabs/PathsTab/PathsTab.tsx
@@ -157,6 +157,30 @@ export function PathsTab({ paths, onChange, onValidationChange }: PathsTabProps)
         </p>
       </div>
 
+      {/* Auto Organize Toggle */}
+      <div className="bg-gray-50 dark:bg-gray-800 rounded-lg p-4 border border-gray-200 dark:border-gray-700">
+        <div className="flex items-start gap-4">
+          <input
+            type="checkbox"
+            id="auto-organize-settings"
+            checked={paths.autoOrganizeEnabled !== false}
+            onChange={(e) => updatePath('autoOrganizeEnabled', e.target.checked)}
+            className="mt-1 h-5 w-5 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+          />
+          <div className="flex-1">
+            <label
+              htmlFor="auto-organize-settings"
+              className="block text-sm font-medium text-gray-900 dark:text-gray-100 cursor-pointer"
+            >
+              Enable Automatic File Organization
+            </label>
+            <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
+              Automatically organize downloaded files from the download directory into the media directory using the templates defined below.
+            </p>
+          </div>
+        </div>
+      </div>
+
       {/* Audiobook Organization Template */}
       <div>
         <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
@@ -168,6 +192,7 @@ export function PathsTab({ paths, onChange, onValidationChange }: PathsTabProps)
           onChange={(e) => updatePath('audiobookPathTemplate', e.target.value)}
           placeholder="{author}/{title} {asin}"
           className="font-mono"
+          disabled={paths.autoOrganizeEnabled === false}
         />
         <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
           Customize how audiobooks are organized within the media directory
@@ -185,7 +210,7 @@ export function PathsTab({ paths, onChange, onValidationChange }: PathsTabProps)
 
         {/* Audiobook Preview Examples */}
         {audiobookPreview && audiobookPreview.isValid && audiobookPreview.previewPaths && (
-          <div className="mt-3 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-4">
+          <div className="mt-3 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-4 opacity-75">
             <h4 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-2">
               Preview Examples
             </h4>
@@ -212,11 +237,12 @@ export function PathsTab({ paths, onChange, onValidationChange }: PathsTabProps)
             onChange={(e) => updatePath('ebookPathTemplate', e.target.value)}
             placeholder="{author}/{title} {asin}"
             className="font-mono flex-1"
+            disabled={paths.autoOrganizeEnabled === false}
           />
           <Button
             variant="outline"
             onClick={() => updatePath('ebookPathTemplate', paths.audiobookPathTemplate || '{author}/{title} {asin}')}
-            disabled={ebookMatchesAudiobook}
+            disabled={ebookMatchesAudiobook || paths.autoOrganizeEnabled === false}
             className="whitespace-nowrap text-sm"
           >
             Match Audiobook
@@ -238,7 +264,7 @@ export function PathsTab({ paths, onChange, onValidationChange }: PathsTabProps)
 
         {/* Ebook Preview Examples */}
         {ebookPreview && ebookPreview.isValid && ebookPreview.previewPaths && (
-          <div className="mt-3 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-4">
+          <div className="mt-3 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-4 opacity-75">
             <h4 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-2">
               Preview Examples
             </h4>
@@ -254,13 +280,14 @@ export function PathsTab({ paths, onChange, onValidationChange }: PathsTabProps)
       </div>
 
       {/* File Rename Toggle */}
-      <div className="bg-gray-50 dark:bg-gray-800 rounded-lg p-4 border border-gray-200 dark:border-gray-700">
+      <div className={`bg-gray-50 dark:bg-gray-800 rounded-lg p-4 border border-gray-200 dark:border-gray-700 ${paths.autoOrganizeEnabled === false ? 'opacity-50' : ''}`}>
         <div className="flex items-start gap-4">
           <input
             type="checkbox"
             id="file-rename-settings"
             checked={paths.fileRenameEnabled}
             onChange={(e) => updatePath('fileRenameEnabled', e.target.checked)}
+            disabled={paths.autoOrganizeEnabled === false}
             className="mt-1 h-5 w-5 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
           />
           <div className="flex-1">
@@ -289,6 +316,7 @@ export function PathsTab({ paths, onChange, onValidationChange }: PathsTabProps)
               onChange={(e) => updatePath('fileRenameTemplate', e.target.value)}
               placeholder="{title}"
               className="font-mono"
+              disabled={paths.autoOrganizeEnabled === false}
             />
             <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
               Uses the same variables as the organization template. Do not include the file extension.
@@ -306,7 +334,7 @@ export function PathsTab({ paths, onChange, onValidationChange }: PathsTabProps)
 
             {/* Filename Preview */}
             {filenamePreview && filenamePreview.isValid && (
-              <div className="mt-3 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-4">
+              <div className="mt-3 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg p-4">
                 <h4 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-2">
                   Single File
                 </h4>
@@ -389,13 +417,14 @@ export function PathsTab({ paths, onChange, onValidationChange }: PathsTabProps)
       </div>
 
       {/* Metadata Tagging Toggle */}
-      <div className="bg-gray-50 dark:bg-gray-800 rounded-lg p-4 border border-gray-200 dark:border-gray-700">
+      <div className={`bg-gray-50 dark:bg-gray-800 rounded-lg p-4 border border-gray-200 dark:border-gray-700 ${paths.autoOrganizeEnabled === false ? 'opacity-50' : ''}`}>
         <div className="flex items-start gap-4">
           <input
             type="checkbox"
             id="metadata-tagging-settings"
             checked={paths.metadataTaggingEnabled}
             onChange={(e) => updatePath('metadataTaggingEnabled', e.target.checked)}
+            disabled={paths.autoOrganizeEnabled === false}
             className="mt-1 h-5 w-5 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
           />
           <div className="flex-1">
@@ -415,13 +444,14 @@ export function PathsTab({ paths, onChange, onValidationChange }: PathsTabProps)
       </div>
 
       {/* Chapter Merging Toggle */}
-      <div className="bg-gray-50 dark:bg-gray-800 rounded-lg p-4 border border-gray-200 dark:border-gray-700">
+      <div className={`bg-gray-50 dark:bg-gray-800 rounded-lg p-4 border border-gray-200 dark:border-gray-700 ${paths.autoOrganizeEnabled === false ? 'opacity-50' : ''}`}>
         <div className="flex items-start gap-4">
           <input
             type="checkbox"
             id="chapter-merging-settings"
             checked={paths.chapterMergingEnabled}
             onChange={(e) => updatePath('chapterMergingEnabled', e.target.checked)}
+            disabled={paths.autoOrganizeEnabled === false}
             className="mt-1 h-5 w-5 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
           />
           <div className="flex-1">
@@ -440,7 +470,7 @@ export function PathsTab({ paths, onChange, onValidationChange }: PathsTabProps)
       </div>
 
       {/* File Permissions */}
-      <div className="bg-gray-50 dark:bg-gray-800 rounded-lg p-4 border border-gray-200 dark:border-gray-700">
+      <div className={`bg-gray-50 dark:bg-gray-800 rounded-lg p-4 border border-gray-200 dark:border-gray-700 ${paths.autoOrganizeEnabled === false ? 'opacity-50' : ''}`}>
         <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-3">
           File Permissions
         </h3>
@@ -457,6 +487,7 @@ export function PathsTab({ paths, onChange, onValidationChange }: PathsTabProps)
               value={paths.fileChmod || '664'}
               onChange={(e) => updatePath('fileChmod', e.target.value)}
               placeholder="664"
+              disabled={paths.autoOrganizeEnabled === false}
               className={`font-mono max-w-32 ${paths.fileChmod && !/^[0-7]{3,4}$/.test(paths.fileChmod) ? 'border-red-500 dark:border-red-500' : ''}`}
             />
             {paths.fileChmod && !/^[0-7]{3,4}$/.test(paths.fileChmod) && (
@@ -475,6 +506,7 @@ export function PathsTab({ paths, onChange, onValidationChange }: PathsTabProps)
               value={paths.dirChmod || '775'}
               onChange={(e) => updatePath('dirChmod', e.target.value)}
               placeholder="775"
+              disabled={paths.autoOrganizeEnabled === false}
               className={`font-mono max-w-32 ${paths.dirChmod && !/^[0-7]{3,4}$/.test(paths.dirChmod) ? 'border-red-500 dark:border-red-500' : ''}`}
             />
             {paths.dirChmod && !/^[0-7]{3,4}$/.test(paths.dirChmod) && (

--- a/src/app/api/admin/settings/paths/route.ts
+++ b/src/app/api/admin/settings/paths/route.ts
@@ -15,7 +15,7 @@ export async function PUT(request: NextRequest) {
   return requireAuth(request, async (req: AuthenticatedRequest) => {
     return requireAdmin(req, async () => {
       try {
-        const { downloadDir, mediaDir, audiobookPathTemplate, ebookPathTemplate, metadataTaggingEnabled, chapterMergingEnabled, fileRenameEnabled, fileRenameTemplate, fileChmod, dirChmod } = await request.json();
+        const { downloadDir, mediaDir, autoOrganizeEnabled, audiobookPathTemplate, ebookPathTemplate, metadataTaggingEnabled, chapterMergingEnabled, fileRenameEnabled, fileRenameTemplate, fileChmod, dirChmod } = await request.json();
 
         if (!downloadDir || !mediaDir) {
           return NextResponse.json(
@@ -58,6 +58,18 @@ export async function PUT(request: NextRequest) {
           where: { key: 'media_dir' },
           update: { value: mediaDir },
           create: { key: 'media_dir', value: mediaDir },
+        });
+
+        // Update auto-organize setting
+        await prisma.configuration.upsert({
+          where: { key: 'auto_organize_enabled' },
+          update: { value: String(autoOrganizeEnabled ?? true) },
+          create: {
+            key: 'auto_organize_enabled',
+            value: String(autoOrganizeEnabled ?? true),
+            category: 'automation',
+            description: 'Automatically organize downloaded files into the media directory',
+          },
         });
 
         // Update audiobook path template
@@ -172,6 +184,7 @@ export async function PUT(request: NextRequest) {
         const configService = getConfigService();
         configService.clearCache('download_dir');
         configService.clearCache('media_dir');
+        configService.clearCache('auto_organize_enabled');
         configService.clearCache('audiobook_path_template');
         configService.clearCache('ebook_path_template');
         configService.clearCache('metadata_tagging_enabled');

--- a/src/app/api/admin/settings/route.ts
+++ b/src/app/api/admin/settings/route.ts
@@ -124,6 +124,7 @@ export async function GET(request: NextRequest) {
       paths: {
         downloadDir: configMap.get('download_dir') || '/downloads',
         mediaDir: configMap.get('media_dir') || '/media/audiobooks',
+        autoOrganizeEnabled: configMap.get('auto_organize_enabled') !== 'false',
         audiobookPathTemplate: configMap.get('audiobook_path_template') || '{author}/{title} {asin}',
         ebookPathTemplate: configMap.get('ebook_path_template') || configMap.get('audiobook_path_template') || '{author}/{title} {asin}',
         metadataTaggingEnabled: configMap.get('metadata_tagging_enabled') === 'true',

--- a/src/lib/processors/monitor-download.processor.ts
+++ b/src/lib/processors/monitor-download.processor.ts
@@ -175,24 +175,62 @@ export async function processMonitorDownload(payload: MonitorDownloadPayload): P
         throw new Error('Request or audiobook not found or deleted');
       }
 
-      // Trigger organize files job with properly constructed path
-      const jobQueue = getJobQueueService();
-      await jobQueue.addOrganizeJob(
-        requestId,
-        request.audiobook.id,
-        organizePath
-      );
+      // Check if auto-organization is enabled
+      const autoOrganizeEnabled = await configService.get('auto_organize_enabled') !== 'false';
 
-      logger.info(`Triggered organize_files job for request ${requestId}`);
+      if (autoOrganizeEnabled) {
+        // Trigger organize files job with properly constructed path
+        const jobQueue = getJobQueueService();
+        await jobQueue.addOrganizeJob(
+          requestId,
+          request.audiobook.id,
+          organizePath
+        );
 
-      return {
-        success: true,
-        completed: true,
-        message: 'Download completed, organizing files',
-        requestId,
-        progress: 100,
-        downloadPath: organizePath,
-      };
+        logger.info(`Triggered organize_files job for request ${requestId}`);
+
+        return {
+          success: true,
+          completed: true,
+          message: 'Download completed, organizing files',
+          requestId,
+          progress: 100,
+          downloadPath: organizePath,
+        };
+      } else {
+        logger.info(`Auto-organization is disabled. Leaving files at ${organizePath}`);
+
+        // Update Request to downloaded
+        await prisma.request.update({
+          where: { id: requestId },
+          data: {
+            status: 'downloaded',
+            progress: 100,
+            completedAt: new Date(),
+            updatedAt: new Date(),
+          },
+        });
+
+        // Update Audiobook so UI knows where files are located
+        await prisma.audiobook.update({
+          where: { id: request.audiobook.id },
+          data: {
+            filePath: organizePath,
+            status: 'completed',
+            completedAt: new Date(),
+            updatedAt: new Date()
+          }
+        });
+
+        return {
+          success: true,
+          completed: true,
+          message: 'Download completed (auto-organize disabled)',
+          requestId,
+          progress: 100,
+          downloadPath: organizePath,
+        };
+      }
     } else if (progressState === 'failed') {
       logger.error(`Download failed for request ${requestId}`);
 

--- a/tests/processors/monitor-download.processor.test.ts
+++ b/tests/processors/monitor-download.processor.test.ts
@@ -18,6 +18,7 @@ const sabMock = vi.hoisted(() => ({
 }));
 const configMock = vi.hoisted(() => ({
   getMany: vi.fn(),
+  get: vi.fn().mockResolvedValue(true),
 }));
 const downloadClientManagerMock = vi.hoisted(() => ({
   getClientForProtocol: vi.fn(),
@@ -42,6 +43,7 @@ vi.mock('@/lib/integrations/sabnzbd.service', () => ({
 
 vi.mock('@/lib/services/config.service', () => ({
   getConfigService: () => configMock,
+  configService: configMock,
 }));
 
 vi.mock('@/lib/services/download-client-manager.service', () => ({
@@ -446,5 +448,3 @@ describe('processMonitorDownload', () => {
     );
   });
 });
-
-


### PR DESCRIPTION
## Summary

- Introduce the ability to globally toggle automatic file organization for completed downloads.
- When disabled, downloaded files are left untouched in the download client's directory, and the request is successfully marked as complete without triggering the organization workflow.

## Changes

- **Types & API**: Added the `auto_organize_enabled` configuration key to the core configuration types and updated the respective API routes to support reading and saving this new boolean preference.
- **Frontend**: Added a new toggle switch for "Automatic File Organization" within the Paths Settings tab, allowing administrators to easily manage this preference from the UI.
- **Job Processors**: Modified the `monitor-download.processor.ts` job to evaluate the `auto_organize_enabled` setting. Upon a successful download, it will now either trigger the standard file organization job, or bypass it entirely and mark the request as complete.

## Use case

Users who prefer to manage their file libraries manually or rely on external tools and scripts to handle sorting, renaming, and moving their audiobooks often clash with built-in automatic organization. By providing a toggle to disable this feature, ReadMeABook can operate strictly as a search, request, and download manager without interfering with external, customized file management workflows. 

## Testing

- Verified that toggling the setting in the Paths Settings tab correctly saves to the backend configuration.
- Tested a completed download with the setting **enabled** to ensure the file organization job is queued and processes normally.
- Tested a completed download with the setting **disabled** to confirm files are left in place and the request transitions directly to the completed state without errors.

## AI Disclosure
🤖 Generated with Google Gemini 3.1 Ultra