### PR TITLE
fix: use BigInt for PlexLibrary.duration to prevent INT4 overflow

### DIFF
--- a/documentation/backend/database.md
+++ b/documentation/backend/database.md
@@ -35,7 +35,7 @@ PostgreSQL database storing users, audiobooks, requests, downloads, configuratio
 
 ### Plex_Library (Library Cache)
 - `id` (UUID PK), `plex_guid` (unique, external ID from Plex or Audiobookshelf), `plex_rating_key`
-- `title`, `author`, `narrator`, `summary`, `duration` (milliseconds), `year`, `user_rating` (0-10 scale)
+- `title`, `author`, `narrator`, `summary`, `duration` (BigInt, milliseconds), `year`, `user_rating` (0-10 scale)
 - **Universal identifiers:** `asin` (Audible ASIN), `isbn` (ISBN-10 or ISBN-13)
 - `file_path`, `thumb_url`, `cached_library_cover_path` (local cached cover path), `plex_library_id`, `added_at`
 - `last_scanned_at`, `created_at`, `updated_at`

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -132,7 +132,7 @@ model PlexLibrary {
   author     String
   narrator   String?
   summary    String?  @db.Text
-  duration   Int? // Duration in milliseconds (Plex format)
+  duration   BigInt? // Duration in milliseconds (Plex format)
   year       Int?
   userRating Decimal? @map("user_rating") @db.Decimal(3, 1) // User's rating (0-10 scale from Plex)
 

--- a/src/lib/processors/plex-recently-added.processor.ts
+++ b/src/lib/processors/plex-recently-added.processor.ts
@@ -106,7 +106,7 @@ export async function processPlexRecentlyAddedCheck(payload: PlexRecentlyAddedPa
             author: item.author || 'Unknown Author',
             narrator: item.narrator,
             summary: item.description,
-            duration: item.duration ? item.duration * 1000 : null, // Convert seconds to milliseconds
+            duration: item.duration ? BigInt(Math.round(item.duration * 1000)) : null, // Convert seconds to milliseconds
             year: item.year,
             asin: item.asin,  // Store ASIN from library backend
             isbn: item.isbn,  // Store ISBN from library backend
@@ -146,7 +146,7 @@ export async function processPlexRecentlyAddedCheck(payload: PlexRecentlyAddedPa
             author: item.author || existing.author,
             narrator: item.narrator || existing.narrator,
             summary: item.description || existing.summary,
-            duration: item.duration ? item.duration * 1000 : existing.duration,
+            duration: item.duration ? BigInt(Math.round(item.duration * 1000)) : existing.duration,
             year: item.year || existing.year,
             asin: item.asin || existing.asin,  // Update ASIN if available
             isbn: item.isbn || existing.isbn,  // Update ISBN if available

--- a/src/lib/processors/scan-plex.processor.ts
+++ b/src/lib/processors/scan-plex.processor.ts
@@ -90,7 +90,7 @@ export async function processScanPlex(payload: ScanPlexPayload): Promise<any> {
               author: item.author || existing.author,
               narrator: item.narrator || existing.narrator,
               summary: item.description || existing.summary,
-              duration: item.duration ? item.duration * 1000 : existing.duration, // Convert seconds to milliseconds
+              duration: item.duration ? BigInt(Math.round(item.duration * 1000)) : existing.duration, // Convert seconds to milliseconds
               year: item.year || existing.year,
               asin: item.asin || existing.asin,  // Store ASIN from library backend
               isbn: item.isbn || existing.isbn,  // Store ISBN from library backend
@@ -132,7 +132,7 @@ export async function processScanPlex(payload: ScanPlexPayload): Promise<any> {
               author: item.author || 'Unknown Author',
               narrator: item.narrator,
               summary: item.description,
-              duration: item.duration ? item.duration * 1000 : null, // Convert seconds to milliseconds
+              duration: item.duration ? BigInt(Math.round(item.duration * 1000)) : null, // Convert seconds to milliseconds
               year: item.year,
               asin: item.asin,  // Store ASIN from library backend (Plex or Audiobookshelf)
               isbn: item.isbn,  // Store ISBN from library backend


### PR DESCRIPTION
## Summary
Fixes #193 — The `RecentlyAdded` job crashes with an INT4 overflow when `prisma.plexLibrary.create()` encounters duration values exceeding the 32-bit signed integer max (2,147,483,647).

## Root Cause
The `duration` column in `plex_library` is PostgreSQL `int4` (via Prisma `Int?`), storing milliseconds. The Audiobookshelf backend returns duration in seconds, which the processor multiplies by 1000. For items with large or erroneous duration metadata, the resulting millisecond value overflows INT4.

**Confirmed via production DB inspection:**
- `duration` column: `int4` (overflow source)
- `plex_rating_key` column: `text` (not affected)
- Failing value: `4082750851` ms (from ABS `media.duration` × 1000)

## Changes
- **`prisma/schema.prisma`**: `PlexLibrary.duration`: `Int?` → `BigInt?` (maps to PostgreSQL `int8`, max ~9.2 quintillion)
- **`src/lib/processors/plex-recently-added.processor.ts`**: Wrap `item.duration * 1000` in `BigInt(Math.round(...))` at the Prisma write boundary
- **`src/lib/processors/scan-plex.processor.ts`**: Same BigInt wrapping

## Migration
Project uses `prisma db push` on container startup — the `int4 → int8` column type change is applied automatically and is safe for existing data (no data loss, no downtime).

## Validation
- ✅ `prisma generate` — client generated successfully
- ✅ `next build` — compiles without errors
- ✅ `vitest run` — all 2,154 tests pass (190 test files)
- ✅ Lint — no new warnings (pre-existing `any` types unchanged)

## AI Transparency
This PR was developed with AI assistance (Oz/Warp). The human author (`@H0tChicken`) reported the issue, provided production logs and DB access for root cause analysis, and reviewed all changes.

Co-Authored-By: Oz <oz-agent@warp.dev>