### PR TITLE
Fix Plex Home profile selection login loop

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -265,10 +265,14 @@ function LoginContent() {
       }
 
       // Poll for authorization
-      await login(pinId);
+      const loginResult = await login(pinId);
 
       // Close popup
       authWindow.close();
+
+      if (loginResult === 'profile-selection-required') {
+        return;
+      }
 
       // Redirect to intended page or homepage
       const redirect = searchParams.get('redirect') || '/';

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -24,11 +24,13 @@ interface User {
   permissions?: UserPermissions;
 }
 
+export type LoginResult = 'authenticated' | 'profile-selection-required';
+
 interface AuthContextType {
   user: User | null;
   accessToken: string | null;
   isLoading: boolean;
-  login: (pinId: number) => Promise<void>;
+  login: (pinId: number) => Promise<LoginResult>;
   logout: () => void;
   refreshToken: () => Promise<void>;
   setAuthData: (user: User, accessToken: string) => void;
@@ -182,7 +184,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   };
 
   // Poll Plex OAuth callback during login
-  const login = async (pinId: number) => {
+  const login = async (pinId: number): Promise<LoginResult> => {
     const maxAttempts = 60; // 2 minutes total
     let attempts = 0;
 
@@ -211,7 +213,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
             // Redirect to profile selection page
             // Note: Plex token is stored server-side for security, not in sessionStorage
             window.location.href = data.redirectUrl;
-            return;
+            return 'profile-selection-required';
           }
 
           // Login successful (no profile selection needed)
@@ -226,7 +228,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           // Schedule auto-refresh
           scheduleTokenRefresh(data.accessToken);
 
-          return;
+          return 'authenticated';
         }
 
         // Still waiting for authorization

--- a/tests/contexts/AuthContext.test.tsx
+++ b/tests/contexts/AuthContext.test.tsx
@@ -20,13 +20,15 @@ vi.mock('@/lib/utils/jwt-client', () => ({
 
 function TestConsumer() {
   const { user, accessToken, isLoading, login, logout, refreshToken, setAuthData } = useAuth();
+  const [loginResult, setLoginResult] = React.useState('none');
 
   return (
     <div>
       <div data-testid="loading">{String(isLoading)}</div>
       <div data-testid="user">{user?.username ?? 'none'}</div>
       <div data-testid="token">{accessToken ?? 'none'}</div>
-      <button type="button" onClick={() => void login(123)}>
+      <div data-testid="login-result">{loginResult}</div>
+      <button type="button" onClick={() => void login(123).then(setLoginResult)}>
         login
       </button>
       <button type="button" onClick={logout}>
@@ -188,6 +190,34 @@ describe('AuthProvider', () => {
     expect(screen.getByTestId('token')).toHaveTextContent('login-access');
     expect(localStorage.getItem('accessToken')).toBe('login-access');
     expect(localStorage.getItem('refreshToken')).toBe('login-refresh');
+    expect(screen.getByTestId('login-result')).toHaveTextContent('authenticated');
+  });
+
+  it('returns profile selection result without storing auth data for Plex Home users', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        success: true,
+        authorized: true,
+        requiresProfileSelection: true,
+        redirectUrl: '/auth/select-profile?pinId=123',
+      }),
+    });
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderAuthProvider();
+
+    fireEvent.click(screen.getByRole('button', { name: 'login' }));
+
+    await waitFor(() => expect(screen.getByTestId('login-result')).toHaveTextContent('profile-selection-required'));
+
+    expect(locationStub.href).toBe('/auth/select-profile?pinId=123');
+    expect(screen.getByTestId('user')).toHaveTextContent('none');
+    expect(screen.getByTestId('token')).toHaveTextContent('none');
+    expect(localStorage.getItem('accessToken')).toBeNull();
+    expect(localStorage.getItem('refreshToken')).toBeNull();
   });
 
   it('logs out by clearing storage and redirecting to the login page', () => {

--- a/tests/helpers/render.tsx
+++ b/tests/helpers/render.tsx
@@ -14,7 +14,7 @@ type RenderWithProvidersOptions = Omit<RenderOptions, 'wrapper'> & {
     user: MockUser | null;
     accessToken: string | null;
     isLoading: boolean;
-    login: (pinId: number) => Promise<void>;
+    login: (pinId: number) => Promise<'authenticated' | 'profile-selection-required'>;
     logout: () => void;
     refreshToken: () => Promise<void>;
     setAuthData: (user: MockUser, accessToken: string) => void;


### PR DESCRIPTION
## Summary
- return an explicit login result from Plex OAuth polling
- stop the desktop login page redirect when Plex Home profile selection is required
- add an AuthContext regression test for the `requiresProfileSelection` callback response

## Problem
For Plex accounts with multiple Plex Home profiles, the callback returns `requiresProfileSelection` and `AuthContext.login()` navigates to `/auth/select-profile`. The desktop login page then continued after `await login(pinId)` and pushed the user to the normal post-login redirect, which could clobber the profile selection flow and send the user back through login.

## Testing
- `npm test -- tests/contexts/AuthContext.test.tsx`
