### PR TITLE
Add seriesPart metadata tag for Audiobookshelf series ordering

### DIFF
--- a/src/lib/utils/file-organizer.ts
+++ b/src/lib/utils/file-organizer.ts
@@ -252,6 +252,8 @@ export class FileOrganizer {
               narrator: audiobook.narrator,
               year: audiobook.year,
               asin: audiobook.asin,
+              series: audiobook.series,
+              seriesPart: audiobook.seriesPart,
             });
 
             const successCount = taggingResults.filter((r) => r.success).length;

--- a/src/lib/utils/metadata-tagger.ts
+++ b/src/lib/utils/metadata-tagger.ts
@@ -17,6 +17,8 @@ export interface MetadataTaggingOptions {
   narrator?: string;
   year?: number;
   asin?: string;
+  series?: string;
+  seriesPart?: string;
 }
 
 export interface TaggingResult {
@@ -83,6 +85,14 @@ export async function tagAudioFileMetadata(
         args.push('-metadata', `----:com.apple.iTunes:ASIN="${escapeMetadata(metadata.asin)}"`);
       }
 
+      if (metadata.series) {
+        args.push('-metadata', `show="${escapeMetadata(metadata.series)}"`);
+      }
+
+      if (metadata.seriesPart) {
+        args.push('-metadata', `episode_id="${escapeMetadata(metadata.seriesPart)}"`);
+      }
+
       // Explicitly specify output format (fixes .tmp extension issue)
       args.push('-f', 'mp4');
     }
@@ -132,6 +142,14 @@ export async function tagAudioFileMetadata(
       if (metadata.asin) {
         // Use TXXX frame for custom ID3v2 tags in MP3 files
         args.push('-metadata', `ASIN="${escapeMetadata(metadata.asin)}"`);
+      }
+
+      if (metadata.series) {
+        args.push('-metadata', `SERIES="${escapeMetadata(metadata.series)}"`);
+      }
+
+      if (metadata.seriesPart) {
+        args.push('-metadata', `SERIES-PART="${escapeMetadata(metadata.seriesPart)}"`);
       }
 
       // Explicitly specify output format (fixes .tmp extension issue)


### PR DESCRIPTION
Problem
When using Audiobookshelf as the backend, books in a series do not display in the correct order because the series sequence number is not written to the audio file tags during the auto-tag step.

Solution
Added series and seriesPart as optional fields to MetadataTaggingOptions and write them as file tags during the auto-tag step:

M4B/MP4: show (series name) and episode_id (series part) — these are the tags ABS reads for series ordering
MP3: SERIES and SERIES-PART custom ID3 tags

Disclaimer
This was written with AI assistance and for personal use. Please review carefully.

