### PR TITLE
Add User-Agent header to Prowlarr RSS queries

### DIFF
--- a/src/lib/integrations/prowlarr.service.ts
+++ b/src/lib/integrations/prowlarr.service.ts
@@ -315,6 +315,9 @@ export class ProwlarrService {
           limit: 100,
           extended: 1,
         },
+        headers: {
+          'User-Agent': 'ReadMeABook',
+        },
         timeout: DOWNLOAD_CLIENT_TIMEOUT,
         responseType: 'text', // Get XML as text
       });


### PR DESCRIPTION
## Summary
- Adds a `User-Agent: ReadMeABook` header to the Prowlarr RSS/Newznab proxy calls so RMAB appears by name in Prowlarr's stats instead of generic "axios"

## Details
- The RSS feed method (`getRssFeed`) uses Prowlarr's Newznab proxy endpoint (`/{indexerId}/api`), which respects the User-Agent header for Source identification
- The search method uses Prowlarr's native `/api/v1/search` endpoint, which hardcodes Source as "Prowlarr" regardless of headers, no change possible from the client side

---

## Testing

Before Code Change

<img width="1830" height="447" alt="image" src="https://github.com/user-attachments/assets/670a9b49-0ea6-4764-aa59-0407301cb976" />

<img width="292" height="229" alt="image" src="https://github.com/user-attachments/assets/97d70697-49df-4a7d-bd6f-99c15165ee4d" />

After Code Change

<img width="944" height="236" alt="image" src="https://github.com/user-attachments/assets/bc4e01f9-6674-476a-bae5-a0c85bcd4415" />

<img width="280" height="221" alt="image" src="https://github.com/user-attachments/assets/623c19fe-a274-47ad-b0df-902e323ce8a0" />

Expectation is axios would eventually fall off and RMAB would show up given the RSS feed polling however since RMAB manual searches hit the prowlarr API directly instead of going to each indexer like sonarr/radarr, those entries would still remain.

---

## AI Disclosure

Claude Sonnet 4.6 was used to develop this PR, I did not see any specific no AI use language for this project but apologies if I overlooked something!