### PR TITLE
feat: allow cancellation of pending-approval requests

### DIFF
--- a/src/app/admin/components/RequestActionsDropdown.tsx
+++ b/src/app/admin/components/RequestActionsDropdown.tsx
@@ -66,7 +66,7 @@ export function RequestActionsDropdown({
   const canSearch = ['pending', 'failed', 'awaiting_search'].includes(request.status);
   const canAdjustSearchTerms = ['pending', 'failed', 'awaiting_search', 'searching'].includes(request.status);
   const canRetryDownload = request.status === 'failed' && (request.downloadAttempts ?? 0) > 0 && !!onRetryDownload;
-  const canCancel = ['pending', 'searching', 'downloading', 'awaiting_search'].includes(request.status);
+  const canCancel = ['pending', 'searching', 'downloading', 'awaiting_search', 'awaiting_approval'].includes(request.status);
   const canDelete = true; // Admins can always delete
 
   // View Source: For ebooks, extract MD5 from slow download URL and link to Anna's Archive
@@ -159,7 +159,11 @@ export function RequestActionsDropdown({
 
   const handleCancel = async () => {
     setIsOpen(false);
-    if (window.confirm(`Are you sure you want to cancel the request for "${request.title}"?`)) {
+    const statusNote = request.status === 'awaiting_approval'
+      ? ' It is pending admin approval and will be withdrawn.'
+      : ' It has already been approved and is actively being processed/monitored.';
+    const message = `Are you sure you want to cancel this request?${statusNote}`;
+    if (window.confirm(message)) {
       try {
         await onCancel(request.requestId);
       } catch (error) {

--- a/src/app/api/requests/[id]/route.ts
+++ b/src/app/api/requests/[id]/route.ts
@@ -112,6 +112,10 @@ export async function PATCH(
           id,
           deletedAt: null, // Only allow updates to active requests
         },
+        include: {
+          audiobook: true,
+          user: { select: { plexUsername: true } },
+        },
       });
 
       if (!requestRecord) {
@@ -130,17 +134,44 @@ export async function PATCH(
       }
 
       if (action === 'cancel') {
-        // Cancel the request
+        const cancellableStatuses = ['pending', 'searching', 'downloading', 'awaiting_search', 'awaiting_approval'];
+        if (!cancellableStatuses.includes(requestRecord.status)) {
+          return NextResponse.json(
+            {
+              error: 'ValidationError',
+              message: `Cannot cancel request with status: ${requestRecord.status}`,
+            },
+            { status: 400 }
+          );
+        }
+
+        const isAwaitingApproval = requestRecord.status === 'awaiting_approval';
+
         const updated = await prisma.request.update({
           where: { id },
           data: {
             status: 'cancelled',
             updatedAt: new Date(),
+            ...(isAwaitingApproval && { selectedTorrent: null as any }),
           },
           include: {
             audiobook: true,
           },
         });
+
+        try {
+          const { getJobQueueService } = await import('@/lib/services/job-queue.service');
+          const jobQueue = getJobQueueService();
+          await jobQueue.addNotificationJob(
+            'request_cancelled',
+            updated.id,
+            updated.audiobook.title,
+            updated.audiobook.author,
+            requestRecord.user.plexUsername || 'Unknown User'
+          );
+        } catch (error) {
+          logger.error('Failed to queue cancellation notification', { error });
+        }
 
         return NextResponse.json({
           success: true,

--- a/src/components/requests/RequestCard.tsx
+++ b/src/components/requests/RequestCard.tsx
@@ -50,12 +50,16 @@ export function RequestCard({ request, showActions = true }: RequestCardProps) {
   const isEbook = requestType === 'ebook';
 
   const isCompleted = COMPLETED_STATUSES.includes(request.status as typeof COMPLETED_STATUSES[number]);
-  const canCancel = ['pending', 'searching', 'downloading', 'awaiting_search'].includes(request.status);
+  const canCancel = ['pending', 'searching', 'downloading', 'awaiting_search', 'awaiting_approval'].includes(request.status);
   const isActive = ['searching', 'downloading', 'processing'].includes(request.status);
   const isFailed = request.status === 'failed';
 
   const handleCancel = async () => {
-    if (window.confirm('Are you sure you want to cancel this request?')) {
+    const statusNote = request.status === 'awaiting_approval'
+      ? ' It is pending admin approval and will be withdrawn.'
+      : ' It has already been approved and is actively being processed/monitored.';
+    const message = `Are you sure you want to cancel this request?${statusNote}`;
+    if (window.confirm(message)) {
       try {
         await cancelRequest(request.id);
       } catch (error) {

--- a/src/lib/constants/notification-events.ts
+++ b/src/lib/constants/notification-events.ts
@@ -77,6 +77,13 @@ export const NOTIFICATION_EVENTS = {
     severity: 'error' as const,
     priority: 'high' as const,
   },
+  request_cancelled: {
+    label: 'Request Cancelled',
+    title: 'Request Cancelled',
+    emoji: '\u{1F6AB}',
+    severity: 'warning' as const,
+    priority: 'normal' as const,
+  },
   issue_reported: {
     label: 'Issue Reported',
     title: 'Issue Reported',

--- a/tests/api/requests-id.route.test.ts
+++ b/tests/api/requests-id.route.test.ts
@@ -9,7 +9,7 @@ import { createPrismaMock } from '../helpers/prisma';
 let authRequest: any;
 
 const prismaMock = createPrismaMock();
-const jobQueueMock = vi.hoisted(() => ({ addSearchJob: vi.fn(), addOrganizeJob: vi.fn() }));
+const jobQueueMock = vi.hoisted(() => ({ addSearchJob: vi.fn(), addOrganizeJob: vi.fn(), addNotificationJob: vi.fn().mockResolvedValue(undefined) }));
 const requireAuthMock = vi.hoisted(() => vi.fn());
 const qbtMock = vi.hoisted(() => ({ getTorrent: vi.fn() }));
 const sabnzbdMock = vi.hoisted(() => ({ getNZB: vi.fn() }));
@@ -115,11 +115,13 @@ describe('Request by ID API routes', () => {
       id: 'req-2',
       userId: 'user-1',
       status: 'pending',
+      user: { plexUsername: 'testuser' },
+      audiobook: { id: 'ab-1', title: 'Test Book', author: 'Test Author' },
     });
     prismaMock.request.update.mockResolvedValueOnce({
       id: 'req-2',
       status: 'cancelled',
-      audiobook: { id: 'ab-1' },
+      audiobook: { id: 'ab-1', title: 'Test Book', author: 'Test Author' },
     });
 
     const { PATCH } = await import('@/app/api/requests/[id]/route');
@@ -128,6 +130,66 @@ describe('Request by ID API routes', () => {
 
     expect(response.status).toBe(200);
     expect(payload.request.status).toBe('cancelled');
+    expect(jobQueueMock.addNotificationJob).toHaveBeenCalledWith(
+      'request_cancelled',
+      'req-2',
+      'Test Book',
+      'Test Author',
+      'testuser'
+    );
+  });
+
+  it('cancels an awaiting_approval request and clears selectedTorrent', async () => {
+    authRequest.json.mockResolvedValue({ action: 'cancel' });
+    prismaMock.request.findFirst.mockResolvedValueOnce({
+      id: 'req-ap',
+      userId: 'user-1',
+      status: 'awaiting_approval',
+      user: { plexUsername: 'testuser' },
+      audiobook: { id: 'ab-ap', title: 'Approval Book', author: 'Some Author' },
+    });
+    prismaMock.request.update.mockResolvedValueOnce({
+      id: 'req-ap',
+      status: 'cancelled',
+      audiobook: { id: 'ab-ap', title: 'Approval Book', author: 'Some Author' },
+    });
+
+    const { PATCH } = await import('@/app/api/requests/[id]/route');
+    const response = await PATCH({} as any, { params: Promise.resolve({ id: 'req-ap' }) });
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.request.status).toBe('cancelled');
+    expect(prismaMock.request.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ selectedTorrent: null }),
+      })
+    );
+    expect(jobQueueMock.addNotificationJob).toHaveBeenCalledWith(
+      'request_cancelled',
+      'req-ap',
+      'Approval Book',
+      'Some Author',
+      'testuser'
+    );
+  });
+
+  it('returns 400 when cancelling a request in a non-cancellable status', async () => {
+    authRequest.json.mockResolvedValue({ action: 'cancel' });
+    prismaMock.request.findFirst.mockResolvedValueOnce({
+      id: 'req-2',
+      userId: 'user-1',
+      status: 'available',
+      user: { plexUsername: 'testuser' },
+      audiobook: { id: 'ab-1', title: 'Test Book', author: 'Test Author' },
+    });
+
+    const { PATCH } = await import('@/app/api/requests/[id]/route');
+    const response = await PATCH({} as any, { params: Promise.resolve({ id: 'req-2' }) });
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload.error).toBe('ValidationError');
   });
 
   it('returns 400 for invalid actions', async () => {


### PR DESCRIPTION
## Summary

Users in `awaiting_approval` status had no way to withdraw their own request. This adds `awaiting_approval` as a cancellable status, fires a `request_cancelled` notification on every cancellation path.

I took some design liberties so feel free to let me know if you want things changed! Example; the confirmation pop out uses the browser based action as opposed to an application custom designed modal.

- Adds `awaiting_approval` to cancellable statuses in `RequestCard` (end user) and `RequestActionsDropdown` (admin)
- Shows a distinct confirmation message when withdrawing a pending-approval request vs cancelling an active one
- Clears `selectedTorrent` on the request record when cancelling an `awaiting_approval` request (prevents stale torrent data)
- Fires the new `request_cancelled` notification event on every cancellation (user or admin path)
- Adds `request_cancelled` to `NOTIFICATION_EVENTS` — auto-propagates to the admin notification settings UI checkbox list
- Adds server-side cancel status gate — returns `400 ValidationError` for non-cancellable statuses so the UI-only `canCancel` guard cannot be bypassed by a direct API call
- Narrows the `user` include on the cancel path to `{ select: { plexUsername: true } }`, consistent with the `GET` handler

## Files Changed

| File | Change |
|------|--------|
| `src/components/requests/RequestCard.tsx` | Added `awaiting_approval` to cancellable statuses; status-aware confirmation message for pending-approval vs active requests |
| `src/app/admin/components/RequestActionsDropdown.tsx` | Same cancellable status and confirmation message changes for the admin dropdown |
| `src/app/api/requests/[id]/route.ts` | Added cancel status gate (400 if status not in cancellable list); narrowed `user` include to `plexUsername` only; clears `selectedTorrent` when cancelling `awaiting_approval` requests; fires `request_cancelled` notification job on every cancel (non-blocking, caught in try/catch) |
| `src/lib/constants/notification-events.ts` | Added `request_cancelled` event with `warning` severity and `normal` priority |
| `tests/api/requests-id.route.test.ts` | Added `addNotificationJob` to job queue mock; asserts notification is fired in existing cancel test; new test for `awaiting_approval` path (verifies `selectedTorrent: null` and notification args); new test for the cancel status gate returning 400 |

## Tested on my UnRaid instance, screenshots here:

1. {End User View} Before the code change

<img width="1332" height="1009" alt="image" src="https://github.com/user-attachments/assets/affb8ebc-7ca0-4f85-b0da-69d5a6e0986a" />

2. {End User View} New UI elements available to cancel

<img width="680" height="527" alt="image" src="https://github.com/user-attachments/assets/da93f4af-58ed-456a-b3ff-1877fe1cf10a" />

3. {End User View} Cancelled before approval

<img width="448" height="164" alt="image" src="https://github.com/user-attachments/assets/21491806-9a09-4486-98bb-2e22f3adec12" />

4. {End User View} Cancelling after approval

<img width="451" height="167" alt="image" src="https://github.com/user-attachments/assets/9e38fd63-493d-40ee-be5a-ca51493d92f9" />

5. {Admin View} Before cancellations

<img width="1123" height="406" alt="image" src="https://github.com/user-attachments/assets/065d4c05-da9d-4f11-aae6-452d3ac2b624" />

6. {Admin View} After cancelling

<img width="938" height="344" alt="image" src="https://github.com/user-attachments/assets/06a956b1-5735-4ac8-9971-50618b33e051" />

7. {End User View} Confirmation I can request the cancelled book again

<img width="598" height="519" alt="image" src="https://github.com/user-attachments/assets/8c220bea-d624-4ea1-bf8e-3c1076a0088e" />

---

## AI Disclosure

Claude Sonnet 4.6 was used to develop this PR, I did not see any specific no AI use language for this project but apologies if I overlooked something!