### PR TITLE
feat: update default audiobook path template for Audiobookshelf compatibility

### DIFF
--- a/documentation/backend/services/config.md
+++ b/documentation/backend/services/config.md
@@ -101,7 +101,7 @@ const CONFIG_DEFAULTS = {
   'system.log_level': 'info',
   'paths.downloads': '/downloads',
   'paths.media_library': '/media',
-  'audiobook_path_template': '{author}/{title} {asin}'
+  'audiobook_path_template': '{author}/{title} {[asin]}'
 };
 ```
 

--- a/documentation/phase3/file-organization.md
+++ b/documentation/phase3/file-organization.md
@@ -10,14 +10,14 @@ Target directory read from database config `media_dir` (configurable in setup wi
 
 **Template-based organization:**
 - Config key: `audiobook_path_template`
-- Default: `{author}/{title} {asin}`
+- Default: `{author}/{title} {[asin]}`
 - Variables: `{author}`, `{title}`, `{narrator}`, `{asin}`, `{year}`
 - Optional variables (narrator, asin, year) are removed if not available
 
 **Examples:**
 ```
-Template: {author}/{title} {asin}
-Result: Douglas Adams/The Hitchhiker's Guide to the Galaxy B0009JKV9W/
+Template: {author}/{title} {[asin]}
+Result: Douglas Adams/The Hitchhiker's Guide to the Galaxy [B0009JKV9W]/
 
 Template: {author}/{title} ({year})
 Result: Douglas Adams/The Hitchhiker's Guide to the Galaxy (2005)/
@@ -200,7 +200,7 @@ async function organize(
 ## Configuration
 
 - **Media directory:** Read from database config key `media_dir` (set in setup wizard or settings)
-- **Path template:** Read from database config key `audiobook_path_template` (default: `{author}/{title} {asin}`)
+- **Path template:** Read from database config key `audiobook_path_template` (default: `{author}/{title} {[asin]}`)
 - **Metadata tagging:** `metadata_tagging_enabled` (boolean, default: true)
 - **Chapter merging:** `chapter_merging_enabled` (boolean, default: false)
 - **Fallback:** `/media/audiobooks` if media_dir not configured

--- a/documentation/settings-pages.md
+++ b/documentation/settings-pages.md
@@ -162,14 +162,14 @@ src/app/admin/settings/
 **Purpose:** Customize how audiobooks are organized within the media directory using variable-based templates.
 
 **Configuration:**
-- Key: `audiobook_path_template` (string, default: `{author}/{title} {asin}`)
+- Key: `audiobook_path_template` (string, default: `{author}/{title} {[asin]}`)
 - Variables: `{author}`, `{title}`, `{narrator}`, `{asin}`, `{year}`
 - Optional variables (narrator, asin, year) removed if not available
 - Template validated on test, shows preview examples
 
 **UI (PathsTab):**
 - Text input with monospace font
-- Placeholder: `{author}/{title} {asin}`
+- Placeholder: `{author}/{title} {[asin]}`
 - Variable reference panel showing all available variables
 - Template validation on "Test Paths" with success/error feedback
 - Preview examples showing 2-3 sample paths with actual data
@@ -181,7 +181,7 @@ src/app/admin/settings/
 - Valid templates show preview paths
 
 **Examples:**
-- `{author}/{title} {asin}` → `Douglas Adams/The Hitchhiker's Guide to the Galaxy B0009JKV9W/`
+- `{author}/{title} {[asin]}` → `Douglas Adams/The Hitchhiker's Guide to the Galaxy [B0009JKV9W]/`
 - `{author}/{title} ({year})` → `Douglas Adams/The Hitchhiker's Guide to the Galaxy (2005)/`
 - `{author}/{narrator}/{title}` → `Douglas Adams/Stephen Fry/The Hitchhiker's Guide to the Galaxy/`
 

--- a/prisma/migrations/20260115000000_add_audiobook_path_template/migration.sql
+++ b/prisma/migrations/20260115000000_add_audiobook_path_template/migration.sql
@@ -7,10 +7,10 @@ INSERT INTO configuration (id, key, value, encrypted, category, description, cre
 VALUES (
   gen_random_uuid(),
   'audiobook_path_template',
-  '{author}/{title} {asin}',
+  '{author}/{title} {[asin]}',
   false,
   'automation',
-  'Template for organizing audiobook file paths. Supports placeholders: {author}, {title}, {asin}. Example: "{author}/{title} {asin}" creates "Author Name/Book Title ASIN/audiobook.m4b"',
+  'Template for organizing audiobook file paths. Supports placeholders: {author}, {title}, {asin}. Example: "{author}/{title} {[asin]}" creates "Author Name/Book Title [ASIN]/audiobook.m4b"',
   NOW(),
   NOW()
 )

--- a/prisma/migrations/20260515000000_update_audiobook_path_template_default/migration.sql
+++ b/prisma/migrations/20260515000000_update_audiobook_path_template_default/migration.sql
@@ -1,0 +1,10 @@
+-- Update default audiobook path template to include square brackets around ASIN
+-- This improves compatibility with Audiobookshelf ASIN extraction
+
+-- Update existing configuration if it matches the old default
+UPDATE configuration
+SET value = '{author}/{title} {[asin]}',
+    description = 'Template for organizing audiobook file paths. Supports placeholders: {author}, {title}, {asin}. Example: "{author}/{title} {[asin]}" creates "Author Name/Book Title [ASIN]/audiobook.m4b"',
+    updated_at = NOW()
+WHERE key = 'audiobook_path_template'
+  AND (value = '{author}/{title} {asin}' OR value IS NULL);

--- a/src/app/admin/settings/tabs/PathsTab/PathsTab.tsx
+++ b/src/app/admin/settings/tabs/PathsTab/PathsTab.tsx
@@ -46,7 +46,7 @@ export function PathsTab({ paths, onChange, onValidationChange }: PathsTabProps)
 
   // Update audiobook live preview whenever template changes
   useEffect(() => {
-    const template = paths.audiobookPathTemplate || '{author}/{title} {asin}';
+    const template = paths.audiobookPathTemplate || '{author}/{title} {[asin]}';
     const validation = validateTemplate(template);
 
     if (validation.valid) {
@@ -64,7 +64,7 @@ export function PathsTab({ paths, onChange, onValidationChange }: PathsTabProps)
 
   // Update ebook live preview whenever template changes
   useEffect(() => {
-    const template = paths.ebookPathTemplate || '{author}/{title} {asin}';
+    const template = paths.ebookPathTemplate || '{author}/{title} {[asin]}';
     const validation = validateTemplate(template);
 
     if (validation.valid) {
@@ -108,8 +108,8 @@ export function PathsTab({ paths, onChange, onValidationChange }: PathsTabProps)
     }
   }, [paths.fileRenameTemplate, paths.fileRenameEnabled]);
 
-  const audiobookTemplate = paths.audiobookPathTemplate || '{author}/{title} {asin}';
-  const ebookTemplate = paths.ebookPathTemplate || '{author}/{title} {asin}';
+  const audiobookTemplate = paths.audiobookPathTemplate || '{author}/{title} {[asin]}';
+  const ebookTemplate = paths.ebookPathTemplate || '{author}/{title} {[asin]}';
   const ebookMatchesAudiobook = ebookTemplate === audiobookTemplate;
 
   return (
@@ -164,9 +164,9 @@ export function PathsTab({ paths, onChange, onValidationChange }: PathsTabProps)
         </label>
         <Input
           type="text"
-          value={paths.audiobookPathTemplate || '{author}/{title} {asin}'}
+          value={paths.audiobookPathTemplate || '{author}/{title} {[asin]}'}
           onChange={(e) => updatePath('audiobookPathTemplate', e.target.value)}
-          placeholder="{author}/{title} {asin}"
+          placeholder="{author}/{title} {[asin]}"
           className="font-mono"
         />
         <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
@@ -208,14 +208,14 @@ export function PathsTab({ paths, onChange, onValidationChange }: PathsTabProps)
         <div className="flex gap-2">
           <Input
             type="text"
-            value={paths.ebookPathTemplate || '{author}/{title} {asin}'}
+            value={paths.ebookPathTemplate || '{author}/{title} {[asin]}'}
             onChange={(e) => updatePath('ebookPathTemplate', e.target.value)}
-            placeholder="{author}/{title} {asin}"
+            placeholder="{author}/{title} {[asin]}"
             className="font-mono flex-1"
           />
           <Button
             variant="outline"
-            onClick={() => updatePath('ebookPathTemplate', paths.audiobookPathTemplate || '{author}/{title} {asin}')}
+            onClick={() => updatePath('ebookPathTemplate', paths.audiobookPathTemplate || '{author}/{title} {[asin]}')}
             disabled={ebookMatchesAudiobook}
             className="whitespace-nowrap text-sm"
           >

--- a/src/app/api/admin/settings/route.ts
+++ b/src/app/api/admin/settings/route.ts
@@ -124,8 +124,8 @@ export async function GET(request: NextRequest) {
       paths: {
         downloadDir: configMap.get('download_dir') || '/downloads',
         mediaDir: configMap.get('media_dir') || '/media/audiobooks',
-        audiobookPathTemplate: configMap.get('audiobook_path_template') || '{author}/{title} {asin}',
-        ebookPathTemplate: configMap.get('ebook_path_template') || configMap.get('audiobook_path_template') || '{author}/{title} {asin}',
+        audiobookPathTemplate: configMap.get('audiobook_path_template') || '{author}/{title} {[asin]}',
+        ebookPathTemplate: configMap.get('ebook_path_template') || configMap.get('audiobook_path_template') || '{author}/{title} {[asin]}',
         metadataTaggingEnabled: configMap.get('metadata_tagging_enabled') === 'true',
         chapterMergingEnabled: configMap.get('chapter_merging_enabled') === 'true',
         fileRenameEnabled: configMap.get('file_rename_enabled') === 'true',

--- a/src/lib/processors/organize-files.processor.ts
+++ b/src/lib/processors/organize-files.processor.ts
@@ -183,7 +183,7 @@ export async function processOrganizeFiles(payload: OrganizeFilesPayload): Promi
     const templateConfig = await prisma.configuration.findUnique({
       where: { key: 'audiobook_path_template' },
     });
-    const template = templateConfig?.value || '{author}/{title} {asin}';
+    const template = templateConfig?.value || '{author}/{title} {[asin]}';
 
     // Read file rename configuration
     const fileRenameEnabledConfig = await prisma.configuration.findUnique({
@@ -674,7 +674,7 @@ async function processEbookOrganization(
     const audiobookTemplateConfig = await prisma.configuration.findUnique({
       where: { key: 'audiobook_path_template' },
     });
-    template = audiobookTemplateConfig?.value || '{author}/{title} {asin}';
+    template = audiobookTemplateConfig?.value || '{author}/{title} {[asin]}';
   }
 
   // Check if Kindle EPUB fix is needed

--- a/src/lib/services/request-delete.service.ts
+++ b/src/lib/services/request-delete.service.ts
@@ -206,7 +206,7 @@ export async function deleteRequest(
       const configService = getConfigService();
       const mediaDir = (await configService.get('media_dir')) || '/media/audiobooks';
       // Use ebook-specific template for ebook requests, with fallback to audiobook template
-      const audiobookTemplate = (await configService.get('audiobook_path_template')) || '{author}/{title} {asin}';
+      const audiobookTemplate = (await configService.get('audiobook_path_template')) || '{author}/{title} {[asin]}';
       const template = isEbook
         ? (await configService.get('ebook_path_template')) || audiobookTemplate
         : audiobookTemplate;

--- a/src/lib/utils/file-organizer.ts
+++ b/src/lib/utils/file-organizer.ts
@@ -1008,7 +1008,7 @@ export async function getFileOrganizer(): Promise<FileOrganizer> {
  * Standalone function for use by other modules (e.g., fetch-ebook route, request-delete service)
  *
  * @param baseDir - Base directory for audiobooks (e.g., /media/audiobooks)
- * @param template - Path template string (e.g., "{author}/{title} {asin}")
+ * @param template - Path template string (e.g., "{author}/{title} {[asin]}")
  * @param variables - Object containing variable values (author, title, narrator, asin)
  * @returns Full path to audiobook directory
  *
@@ -1016,10 +1016,10 @@ export async function getFileOrganizer(): Promise<FileOrganizer> {
  * ```typescript
  * const path = buildAudiobookPath(
  *   '/media/audiobooks',
- *   '{author}/{title} {asin}',
+ *   '{author}/{title} {[asin]}',
  *   { author: 'Brandon Sanderson', title: 'Mistborn', asin: 'B002UZMLXM' }
  * );
- * // Returns: "/media/audiobooks/Brandon Sanderson/Mistborn B002UZMLXM"
+ * // Returns: "/media/audiobooks/Brandon Sanderson/Mistborn [B002UZMLXM]"
  * ```
  */
 export function buildAudiobookPath(

--- a/tests/lib/utils/path-template.util.test.ts
+++ b/tests/lib/utils/path-template.util.test.ts
@@ -16,7 +16,7 @@ import {
 
 describe('substituteTemplate', () => {
   it('should substitute all valid variables', () => {
-    const template = '{author}/{title}/{narrator}/{asin}';
+    const template = '{author}/{title}/{narrator}/{[asin]}';
     const variables: TemplateVariables = {
       author: 'Brandon Sanderson',
       title: 'Mistborn',
@@ -25,7 +25,7 @@ describe('substituteTemplate', () => {
     };
 
     const result = substituteTemplate(template, variables);
-    expect(result).toBe('Brandon Sanderson/Mistborn/Michael Kramer/B002UZMLXM');
+    expect(result).toBe('Brandon Sanderson/Mistborn/Michael Kramer/[B002UZMLXM]');
   });
 
   it('should handle missing optional variables gracefully', () => {
@@ -361,7 +361,7 @@ describe('validateTemplate', () => {
       '{author}/{title}/{narrator}',
       'Audiobooks/{author}/{title}',
       '{author} - {title}',
-      '{author}/{title}/{asin}'
+      '{author}/{title}/{[asin]}'
     ];
 
     templates.forEach(template => {
@@ -556,25 +556,25 @@ describe('generateMockPreviews', () => {
   });
 
   it('should include ASIN in examples when requested', () => {
-    const template = '{author}/{title}/{asin}';
+    const template = '{author}/{title}/{[asin]}';
     const previews = generateMockPreviews(template);
 
     // All examples should have ASIN (mock data includes it)
     previews.forEach(preview => {
       const parts = preview.split('/');
       expect(parts.length).toBe(3);
-      expect(parts[2]).toMatch(/^B[A-Z0-9]+$/); // ASIN format
+      expect(parts[2]).toMatch(/^\[B[A-Z0-9]+\]$/); // ASIN format with brackets
     });
   });
 
   it('should handle complex templates with static text', () => {
-    const template = 'Library/{author}/Books/{title} - {asin}';
+    const template = 'Library/{author}/Books/{title} - {[asin]}';
     const previews = generateMockPreviews(template);
 
     previews.forEach(preview => {
       expect(preview).toContain('Library/');
       expect(preview).toContain('/Books/');
-      expect(preview).toContain(' - B');
+      expect(preview).toContain(' - [B');
     });
   });
 

--- a/tests/processors/organize-files.processor.test.ts
+++ b/tests/processors/organize-files.processor.test.ts
@@ -71,7 +71,7 @@ describe('processOrganizeFiles', () => {
     configMock.get.mockImplementation(async (key: string) => {
       if (key === 'plex.trigger_scan_after_import') return 'true';
       if (key === 'plex_audiobook_library_id') return 'lib-1';
-      if (key === 'audiobook_path_template') return '{author}/{title} {asin}';
+      if (key === 'audiobook_path_template') return '{author}/{title} {[asin]}';
       return null;
     });
 
@@ -225,7 +225,7 @@ describe('processOrganizeFiles', () => {
       deletedAt: null,
     });
     configMock.get.mockImplementation(async (key: string) => {
-      if (key === 'audiobook_path_template') return '{author}/{title} {asin}';
+      if (key === 'audiobook_path_template') return '{author}/{title} {[asin]}';
       return null;
     });
 
@@ -373,7 +373,7 @@ describe('processOrganizeFiles', () => {
       deletedAt: null,
     });
     configMock.get.mockImplementation(async (key: string) => {
-      if (key === 'audiobook_path_template') return '{author}/{title} {asin}';
+      if (key === 'audiobook_path_template') return '{author}/{title} {[asin]}';
       return null;
     });
 

--- a/tests/services/request-delete.service.test.ts
+++ b/tests/services/request-delete.service.test.ts
@@ -91,7 +91,7 @@ describe('deleteRequest', () => {
         return '/media';
       }
       if (key === 'audiobook_path_template') {
-        return '{author}/{title} {asin}';
+        return '{author}/{title} {[asin]}';
       }
       return null;
     });
@@ -236,7 +236,7 @@ describe('deleteRequest', () => {
         return '/media';
       }
       if (key === 'audiobook_path_template') {
-        return '{author}/{title} {asin}';
+        return '{author}/{title} {[asin]}';
       }
       return null;
     });
@@ -409,7 +409,7 @@ describe('deleteRequest', () => {
         return '/media';
       }
       if (key === 'audiobook_path_template') {
-        return '{author}/{title} {asin}';
+        return '{author}/{title} {[asin]}';
       }
       return null;
     });

--- a/tests/utils/file-organizer.test.ts
+++ b/tests/utils/file-organizer.test.ts
@@ -291,7 +291,7 @@ describe('file organizer', () => {
     });
 
     const sourcePath = path.join('/downloads', 'book', 'book.m4b');
-    const expectedDir = path.join('/media', 'Author', 'Book ASIN123');
+    const expectedDir = path.join('/media', 'Author', 'Book [ASIN123]');
     const targetFile = path.join(expectedDir, 'book.m4b');
 
     fsMock.access.mockImplementation(async (filePath: string) => {
@@ -310,7 +310,7 @@ describe('file organizer', () => {
       author: 'Author',
       asin: 'ASIN123',
       coverArtUrl: 'https://images.example/cover.jpg',
-    }, '{author}/{title} {asin}');
+    }, '{author}/{title} {[asin]}');
 
     expect(result.success).toBe(true);
     expect(result.coverArtFile).toBe(path.join(expectedDir, 'cover.jpg'));


### PR DESCRIPTION
This PR updates the default audiobook path template to `{author}/{title} {[asin]}` to ensure compatibility with [Audiobookshelf's ASIN extraction requirements](https://github.com/advplyr/audiobookshelf/blob/eee377e0817d99f66b1b2da08ee7c366bfd606ee/server/utils/scandir.js#L265-L275). 

### Changes:
- Updated default pattern in `request-delete.service.ts`, `organize-files.processor.ts`, and `file-organizer.ts`.
- Updated UI placeholders and fallbacks in `PathsTab.tsx`.
- Added a database migration (`20260515000000_update_audiobook_path_template_default`) to update existing configurations.
- Updated documentation and test suites to reflect the new default format while maintaining raw ASIN strings in non-template contexts.