### PR TITLE
Fixes a 403 Issue where NZBFinder rejected requests with "axios/x.y.z" user-agent string

### DIFF
--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,7 +1,0 @@
-export async function register() {
-  if (process.env.NEXT_RUNTIME === 'nodejs') {
-    const axios = (await import('axios')).default;
-    const { RMAB_USER_AGENT } = await import('@/lib/utils/user-agent');
-    axios.defaults.headers.common['User-Agent'] = RMAB_USER_AGENT;
-  }
-}

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,0 +1,7 @@
+export async function register() {
+  if (process.env.NEXT_RUNTIME === 'nodejs') {
+    const axios = (await import('axios')).default;
+    const { RMAB_USER_AGENT } = await import('@/lib/utils/user-agent');
+    axios.defaults.headers.common['User-Agent'] = RMAB_USER_AGENT;
+  }
+}

--- a/src/lib/integrations/audible.service.ts
+++ b/src/lib/integrations/audible.service.ts
@@ -4,6 +4,7 @@
  */
 
 import axios, { AxiosInstance } from 'axios';
+import { RMAB_USER_AGENT } from '../utils/user-agent';
 import * as cheerio from 'cheerio';
 import { RMABLogger } from '../utils/logger';
 import { getConfigService } from '../services/config.service';
@@ -273,7 +274,7 @@ export class AudibleService {
         timeout: 10000,
         headers: {
           Accept: 'application/json',
-          'User-Agent': 'ReadMeABook/1.0',
+          'User-Agent': RMAB_USER_AGENT,
         },
       });
 
@@ -305,7 +306,7 @@ export class AudibleService {
         timeout: 10000,
         headers: {
           Accept: 'application/json',
-          'User-Agent': 'ReadMeABook/1.0',
+          'User-Agent': RMAB_USER_AGENT,
         },
       });
 

--- a/src/lib/integrations/audnexus-authors.ts
+++ b/src/lib/integrations/audnexus-authors.ts
@@ -7,13 +7,14 @@
  */
 
 import axios from 'axios';
+import { RMAB_USER_AGENT } from '@/lib/utils/user-agent';
 import { RMABLogger } from '@/lib/utils/logger';
 
 const logger = RMABLogger.create('Audnexus.Authors');
 
 const AUDNEXUS_BASE = 'https://api.audnex.us';
 const AUDNEXUS_TIMEOUT = 10000;
-const AUDNEXUS_HEADERS = { 'User-Agent': 'ReadMeABook/1.0' };
+const AUDNEXUS_HEADERS = { 'User-Agent': RMAB_USER_AGENT };
 
 export interface AudnexusAuthorSearch {
   asin: string;

--- a/src/lib/integrations/deluge.service.ts
+++ b/src/lib/integrations/deluge.service.ts
@@ -193,6 +193,7 @@ export class DelugeService implements IDownloadClient {
       torrentResponse = await axios.get(torrentUrl, {
         responseType: 'arraybuffer', maxRedirects: 0,
         validateStatus: (s) => s >= 200 && s < 300, timeout: DOWNLOAD_CLIENT_TIMEOUT,
+        headers: { 'User-Agent': RMAB_USER_AGENT },
       });
       if (torrentResponse.data.length > 0) {
         const magnetMatch = torrentResponse.data.toString().match(/^magnet:\?[^\s]+$/);
@@ -205,7 +206,7 @@ export class DelugeService implements IDownloadClient {
         const loc = error.response.headers['location'];
         if (loc?.startsWith('magnet:')) return this.addMagnetLink(loc, category, options);
         if (loc?.startsWith('http://') || loc?.startsWith('https://')) {
-          try { torrentResponse = await axios.get(loc, { responseType: 'arraybuffer', timeout: DOWNLOAD_CLIENT_TIMEOUT, maxRedirects: 5 }); }
+          try { torrentResponse = await axios.get(loc, { responseType: 'arraybuffer', timeout: DOWNLOAD_CLIENT_TIMEOUT, maxRedirects: 5, headers: { 'User-Agent': RMAB_USER_AGENT } }); }
           catch { throw new Error('Failed to download torrent file after redirect'); }
         } else { throw new Error(`Invalid redirect location: ${loc}`); }
       } else { throw new Error(`Failed to download torrent: HTTP ${status}`); }

--- a/src/lib/integrations/deluge.service.ts
+++ b/src/lib/integrations/deluge.service.ts
@@ -4,6 +4,7 @@
  */
 
 import axios, { AxiosInstance } from 'axios';
+import { RMAB_USER_AGENT } from '../utils/user-agent';
 import https from 'https';
 import path from 'path';
 import { DOWNLOAD_CLIENT_TIMEOUT } from '../constants/download-timeouts';
@@ -50,7 +51,7 @@ export class DelugeService implements IDownloadClient {
       ? new https.Agent({ rejectUnauthorized: false }) : undefined;
     if (httpsAgent) logger.info('[Deluge] SSL certificate verification disabled');
 
-    this.client = axios.create({ baseURL: this.baseUrl, timeout: DOWNLOAD_CLIENT_TIMEOUT, httpsAgent });
+    this.client = axios.create({ baseURL: this.baseUrl, timeout: DOWNLOAD_CLIENT_TIMEOUT, httpsAgent, headers: { 'User-Agent': RMAB_USER_AGENT } });
   }
 
   /** JSON-RPC call with automatic re-authentication on auth failure */

--- a/src/lib/integrations/nzbget.service.ts
+++ b/src/lib/integrations/nzbget.service.ts
@@ -4,6 +4,7 @@
  */
 
 import axios, { AxiosInstance } from 'axios';
+import { RMAB_USER_AGENT } from '@/lib/utils/user-agent';
 import https from 'https';
 import zlib from 'zlib';
 import { RMABLogger } from '@/lib/utils/logger';
@@ -140,6 +141,7 @@ export class NZBGetService implements IDownloadClient {
       baseURL: this.baseUrl,
       timeout: 30000,
       httpsAgent: this.httpsAgent,
+      headers: { 'User-Agent': RMAB_USER_AGENT },
       auth: {
         username: this.username,
         password: this.password,
@@ -226,7 +228,10 @@ export class NZBGetService implements IDownloadClient {
         responseType: 'arraybuffer',
         timeout: 30000,
         maxRedirects: 5,
-        headers: options?.sourceHeaders,
+        headers: {
+          'User-Agent': RMAB_USER_AGENT,
+          ...options?.sourceHeaders,
+        },
         httpsAgent: url.startsWith('https') ? this.httpsAgent : undefined,
       });
 

--- a/src/lib/integrations/plex.service.ts
+++ b/src/lib/integrations/plex.service.ts
@@ -4,6 +4,7 @@
  */
 
 import axios, { AxiosInstance } from 'axios';
+import { RMAB_USER_AGENT } from '../utils/user-agent';
 import { parseStringPromise } from 'xml2js';
 import { RMABLogger } from '../utils/logger';
 
@@ -83,6 +84,7 @@ export class PlexService {
   constructor() {
     this.client = axios.create({
       timeout: 10000,
+      headers: { 'User-Agent': RMAB_USER_AGENT },
     });
   }
 

--- a/src/lib/integrations/prowlarr.service.ts
+++ b/src/lib/integrations/prowlarr.service.ts
@@ -4,6 +4,7 @@
  */
 
 import axios, { AxiosInstance } from 'axios';
+import { RMAB_USER_AGENT } from '../utils/user-agent';
 import { XMLParser } from 'fast-xml-parser';
 import { DOWNLOAD_CLIENT_TIMEOUT } from '../constants/download-timeouts';
 import { TorrentResult } from '../utils/ranking-algorithm';
@@ -86,6 +87,7 @@ export class ProwlarrService {
     this.client = axios.create({
       baseURL: `${this.baseUrl}/api/v1`,
       headers: {
+        'User-Agent': RMAB_USER_AGENT,
         'X-Api-Key': this.apiKey,
       },
       timeout: DOWNLOAD_CLIENT_TIMEOUT,

--- a/src/lib/integrations/prowlarr.service.ts
+++ b/src/lib/integrations/prowlarr.service.ts
@@ -318,7 +318,7 @@ export class ProwlarrService {
           extended: 1,
         },
         headers: {
-          'User-Agent': 'ReadMeABook',
+          'User-Agent': RMAB_USER_AGENT,
         },
         timeout: DOWNLOAD_CLIENT_TIMEOUT,
         responseType: 'text', // Get XML as text

--- a/src/lib/integrations/qbittorrent.service.ts
+++ b/src/lib/integrations/qbittorrent.service.ts
@@ -4,6 +4,7 @@
  */
 
 import axios, { AxiosInstance } from 'axios';
+import { RMAB_USER_AGENT } from '../utils/user-agent';
 import https from 'https';
 import path from 'path';
 import { DOWNLOAD_CLIENT_TIMEOUT } from '../constants/download-timeouts';
@@ -149,6 +150,7 @@ export class QBittorrentService implements IDownloadClient {
       baseURL: `${this.baseUrl}/api/v2`,
       timeout: DOWNLOAD_CLIENT_TIMEOUT,
       httpsAgent: this.httpsAgent,
+      headers: { 'User-Agent': RMAB_USER_AGENT },
       // Support nginx/Apache reverse proxy with HTTP Basic Auth
       auth: {
         username: this.username,

--- a/src/lib/integrations/sabnzbd.service.ts
+++ b/src/lib/integrations/sabnzbd.service.ts
@@ -4,6 +4,7 @@
  */
 
 import axios, { AxiosInstance } from 'axios';
+import { RMAB_USER_AGENT } from '@/lib/utils/user-agent';
 import https from 'https';
 import FormData from 'form-data';
 import { RMABLogger } from '@/lib/utils/logger';
@@ -132,6 +133,7 @@ export class SABnzbdService implements IDownloadClient {
       baseURL: this.baseUrl,
       timeout: 30000,
       httpsAgent: this.httpsAgent,
+      headers: { 'User-Agent': RMAB_USER_AGENT },
     });
   }
 
@@ -494,7 +496,10 @@ export class SABnzbdService implements IDownloadClient {
         responseType: 'arraybuffer',
         timeout: 30000,
         maxRedirects: 5,
-        headers: options?.sourceHeaders,
+        headers: {
+          'User-Agent': RMAB_USER_AGENT,
+          ...options?.sourceHeaders,
+        },
         // Use the same SSL settings as the SABnzbd client if the NZB URL
         // happens to be served over HTTPS with a self-signed cert
         httpsAgent: url.startsWith('https') ? this.httpsAgent : undefined,

--- a/src/lib/integrations/transmission.service.ts
+++ b/src/lib/integrations/transmission.service.ts
@@ -4,6 +4,7 @@
  */
 
 import axios, { AxiosInstance } from 'axios';
+import { RMAB_USER_AGENT } from '../utils/user-agent';
 import https from 'https';
 import path from 'path';
 import { DOWNLOAD_CLIENT_TIMEOUT } from '../constants/download-timeouts';
@@ -109,6 +110,7 @@ export class TransmissionService implements IDownloadClient {
       baseURL: this.baseUrl,
       timeout: DOWNLOAD_CLIENT_TIMEOUT,
       httpsAgent: this.httpsAgent,
+      headers: { 'User-Agent': RMAB_USER_AGENT },
     });
   }
 

--- a/src/lib/integrations/transmission.service.ts
+++ b/src/lib/integrations/transmission.service.ts
@@ -278,6 +278,7 @@ export class TransmissionService implements IDownloadClient {
         maxRedirects: 0,
         validateStatus: (status) => status >= 200 && status < 300,
         timeout: DOWNLOAD_CLIENT_TIMEOUT,
+        headers: { 'User-Agent': RMAB_USER_AGENT },
       });
 
       // Check if response body is a magnet link
@@ -307,6 +308,7 @@ export class TransmissionService implements IDownloadClient {
               responseType: 'arraybuffer',
               timeout: DOWNLOAD_CLIENT_TIMEOUT,
               maxRedirects: 5,
+              headers: { 'User-Agent': RMAB_USER_AGENT },
             });
           } catch {
             throw new Error('Failed to download torrent file after redirect');

--- a/src/lib/processors/direct-download.processor.ts
+++ b/src/lib/processors/direct-download.processor.ts
@@ -12,6 +12,7 @@ import { getConfigService } from '../services/config.service';
 import { RMABLogger } from '../utils/logger';
 import { extractDownloadUrl, ExtractedDownload } from '../services/ebook-scraper';
 import axios from 'axios';
+import { RMAB_USER_AGENT } from '../utils/user-agent';
 import fs from 'fs/promises';
 import { createWriteStream } from 'fs';
 import path from 'path';
@@ -302,7 +303,7 @@ async function downloadFileWithProgress(
       responseType: 'stream',
       timeout: DOWNLOAD_TIMEOUT_MS,
       headers: {
-        'User-Agent': 'ReadMeABook/1.0 (Audiobook Automation)',
+        'User-Agent': RMAB_USER_AGENT,
       },
     });
 

--- a/src/lib/services/ebook-scraper.ts
+++ b/src/lib/services/ebook-scraper.ts
@@ -20,7 +20,6 @@ export interface EbookDownloadResult {
   error?: string;
 }
 
-const USER_AGENT = RMAB_USER_AGENT;
 const REQUEST_DELAY_MS = 1500; // 1.5 second delay between requests
 const DOWNLOAD_TIMEOUT_MS = 60000; // 60 seconds per download attempt
 const MAX_SLOW_LINK_ATTEMPTS = 5;
@@ -114,7 +113,7 @@ async function fetchHtml(
   moduleLogger.debug(`Using direct request for: ${url}`);
   const response = await retryRequest(() =>
     axios.get(url, {
-      headers: { 'User-Agent': USER_AGENT },
+      headers: { 'User-Agent': RMAB_USER_AGENT },
       timeout: 30000,
     })
   );
@@ -655,7 +654,7 @@ async function downloadFile(
     const response = await axios.get(url, {
       responseType: 'stream',
       timeout: DOWNLOAD_TIMEOUT_MS,
-      headers: { 'User-Agent': USER_AGENT },
+      headers: { 'User-Agent': RMAB_USER_AGENT },
       maxRedirects: 5,
     });
 

--- a/src/lib/services/ebook-scraper.ts
+++ b/src/lib/services/ebook-scraper.ts
@@ -4,6 +4,7 @@
  */
 
 import axios, { AxiosError } from 'axios';
+import { RMAB_USER_AGENT } from '../utils/user-agent';
 import * as cheerio from 'cheerio';
 import fs from 'fs/promises';
 import path from 'path';
@@ -19,7 +20,7 @@ export interface EbookDownloadResult {
   error?: string;
 }
 
-const USER_AGENT = 'ReadMeABook/1.0 (Audiobook Automation)';
+const USER_AGENT = RMAB_USER_AGENT;
 const REQUEST_DELAY_MS = 1500; // 1.5 second delay between requests
 const DOWNLOAD_TIMEOUT_MS = 60000; // 60 seconds per download attempt
 const MAX_SLOW_LINK_ATTEMPTS = 5;

--- a/src/lib/services/goodreads-sync.service.ts
+++ b/src/lib/services/goodreads-sync.service.ts
@@ -7,6 +7,7 @@
  */
 
 import axios from 'axios';
+import { RMAB_USER_AGENT } from '@/lib/utils/user-agent';
 import { XMLParser } from 'fast-xml-parser';
 import { prisma } from '@/lib/db';
 import { Prisma } from '@/generated/prisma/client';
@@ -83,7 +84,7 @@ export async function fetchAndValidateRss(rssUrl: string): Promise<{ shelfName: 
   for (let page = 1; page <= MAX_PAGES; page++) {
     url.searchParams.set('page', page.toString());
 
-    const response = await axios.get(url.toString(), { timeout: 15000 });
+    const response = await axios.get(url.toString(), { timeout: 15000, headers: { 'User-Agent': RMAB_USER_AGENT } });
     const parsed = parseGoodreadsRss(response.data);
 
     if (page === 1) {

--- a/src/lib/services/hardcover-api.service.ts
+++ b/src/lib/services/hardcover-api.service.ts
@@ -7,6 +7,7 @@
  */
 
 import axios from 'axios';
+import { RMAB_USER_AGENT } from '@/lib/utils/user-agent';
 import { RMABLogger } from '@/lib/utils/logger';
 
 const logger = RMABLogger.create('HardcoverAPI');
@@ -120,6 +121,7 @@ export async function fetchHardcoverList(
           headers: {
             Authorization: `Bearer ${apiToken}`,
             'Content-Type': 'application/json',
+            'User-Agent': RMAB_USER_AGENT,
           },
           timeout: 30000,
         },

--- a/src/lib/services/thumbnail-cache.service.ts
+++ b/src/lib/services/thumbnail-cache.service.ts
@@ -7,6 +7,7 @@ import fs from 'fs/promises';
 import path from 'path';
 import crypto from 'crypto';
 import axios from 'axios';
+import { RMAB_USER_AGENT } from '../utils/user-agent';
 import { RMABLogger } from '../utils/logger';
 
 const logger = RMABLogger.create('ThumbnailCache');
@@ -110,7 +111,7 @@ export class ThumbnailCacheService {
         timeout: TIMEOUT_MS,
         maxContentLength: MAX_FILE_SIZE,
         headers: {
-          'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
+          'User-Agent': RMAB_USER_AGENT,
         },
       });
 
@@ -185,7 +186,7 @@ export class ThumbnailCacheService {
         timeout: TIMEOUT_MS,
         maxContentLength: MAX_FILE_SIZE,
         headers: {
-          'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
+          'User-Agent': RMAB_USER_AGENT,
           ...(backendMode === 'audiobookshelf' && { Authorization: `Bearer ${authToken}` }),
         },
       });

--- a/src/lib/utils/file-organizer.ts
+++ b/src/lib/utils/file-organizer.ts
@@ -6,6 +6,7 @@
 import fs from 'fs/promises';
 import path from 'path';
 import axios from 'axios';
+import { RMAB_USER_AGENT } from './user-agent';
 import { tagMultipleFiles, checkFfmpegAvailable } from './metadata-tagger';
 import { RMABLogger } from './logger';
 import { copyFile } from './copy-file';
@@ -740,6 +741,7 @@ export class FileOrganizer {
         const response = await axios.get(url, {
           responseType: 'arraybuffer',
           timeout: 30000,
+          headers: { 'User-Agent': RMAB_USER_AGENT },
         });
 
         await fs.writeFile(targetPath, response.data);

--- a/src/lib/utils/user-agent.ts
+++ b/src/lib/utils/user-agent.ts
@@ -1,0 +1,3 @@
+import { version } from '../../../package.json';
+
+export const RMAB_USER_AGENT = `rmab/${version}`;


### PR DESCRIPTION
user-agent.ts
    defines global user-agent string for all http requests

instrumentation.ts
    sets axios default user-agent to our global user-agent string on library import