### PR TITLE
fix: CamelCase author names fail automatic search matching

### DIFF
--- a/src/lib/utils/ranking-algorithm.ts
+++ b/src/lib/utils/ranking-algorithm.ts
@@ -389,11 +389,12 @@ export class RankingAlgorithm {
 
     // Parse authors from RAW string first (preserving commas for splitting)
     // Then normalize individual authors for matching
-    const requestAuthorRaw = audiobook.author.toLowerCase().replace(/\s+/g, ' ').trim();
-    const parsedAuthors = requestAuthorRaw
-      .split(/,|&| and | - /)
+    const parsedAuthors = audiobook.author
+      .replace(/\s+/g, ' ')
+      .trim()
+      .split(/,|&| and | - /i)
       .map(a => a.trim())
-      .filter(a => a.length > 2 && !['translator', 'narrator'].includes(a));
+      .filter(a => a.length > 2 && !['translator', 'narrator'].includes(a.toLowerCase()));
 
     // Normalize parsed authors for matching (handles CamelCase in author names)
     const normalizedAuthors = parsedAuthors.map(a => this.normalizeForMatching(a, characterReplacements));

--- a/tests/utils/ranking-algorithm.test.ts
+++ b/tests/utils/ranking-algorithm.test.ts
@@ -1348,6 +1348,36 @@ describe('ranking-algorithm', () => {
       // Gets partial score from fuzzy matching (title words + author words present)
       expect(breakdown.matchScore).toBeGreaterThan(30);
     });
+
+    it('matches CamelCase author prefix "McGowan" in request author field', () => {
+      const torrent = {
+        ...baseTorrent,
+        title: 'The Housekeeper by Suellen McGowan [M4B]',
+      };
+
+      const breakdown = algorithm.getScoreBreakdown(torrent, {
+        title: 'The Housekeeper',
+        author: 'Suellen McGowan',
+      }, true);
+
+      // "McGowan" must survive into normalizeForMatching as "Mc Gowan"
+      // With requireAuthor: true, author presence check must pass
+      expect(breakdown.matchScore).toBeGreaterThanOrEqual(50);
+    });
+
+    it('matches CamelCase author prefix "McFadden" in request author field', () => {
+      const torrent = {
+        ...baseTorrent,
+        title: 'The Housemaid - Freida McFadden [M4B]',
+      };
+
+      const breakdown = algorithm.getScoreBreakdown(torrent, {
+        title: 'The Housemaid',
+        author: 'Freida McFadden',
+      }, true);
+
+      expect(breakdown.matchScore).toBeGreaterThanOrEqual(50);
+    });
   });
 
   describe('Legacy API Compatibility', () => {


### PR DESCRIPTION
## Summary

- Authors with CamelCase prefixes (Mc, Mac) silently fail automatic search
- `scoreMatch()` calls `.toLowerCase()` before parsing authors, destroying the casing that `normalizeForMatching()` relies on to split prefixes like "McGowan" → "Mc Gowan"
- The CamelCase split regex `/([a-z])([A-Z])/g` never matches on already-lowercased input, so "mcgowan" stays unsplit and fails the author presence check
- Automatic mode sets `requireAuthor: true`, so these results get `matchScore: 0` and fall below the 50-point threshold
- Interactive search is unaffected because it uses `requireAuthor: false`
- Affected names include McGowan, McFadden, McAllister, McGinnis, and any Mc/Mac prefix author

## Files Changed

| File | Change |
|------|--------|
| `src/lib/utils/ranking-algorithm.ts` | Remove premature `.toLowerCase()` before author parsing so CamelCase survives into `normalizeForMatching()`. Add `/i` flag to split regex, move lowercase into filter comparison. |
| `tests/utils/ranking-algorithm.test.ts` | Add test cases for CamelCase author name matching (McGowan, McFadden) |

## Testing

- All existing tests pass (`vitest run`)
- Existing McFadden test (expects matchScore < 45 for title mismatch) still passes at 37.5
- New tests verify McGowan and McFadden score ≥ 50 when title and author both match
- Verified against live Prowlarr results: McGowan "The Housekeeper" scores 78 with fix vs 0 without

## AI Disclosure

Found the bug manually by tracing why automatic searches kept returning 0 grabs for Mc-prefix authors. Used Claude to help develop and validate the fix. All changes reviewed and tested against a live instance.