### PR TITLE
feat: Automatically tag Audiobookshelf items with req:<username> per requester

### DIFF
--- a/documentation/TABLEOFCONTENTS.md
+++ b/documentation/TABLEOFCONTENTS.md
@@ -28,6 +28,7 @@
 - **Availability status, plexGuid linking** → [integrations/plex.md](integrations/plex.md)
 
 ## Audiobookshelf Integration
+- **Requester tagging (`req:<username>` per requester)** → [features/requester-tags.md](features/requester-tags.md)
 - **ABS API client, library scanning** → `src/lib/services/audiobookshelf/api.ts`
 - **ABS library service** → `src/lib/services/library/AudiobookshelfLibraryService.ts`
 - **Backend mode selection (Plex vs ABS)** → [backend/services/config.md](backend/services/config.md)
@@ -166,6 +167,8 @@
 **"How does logging work?"** → [backend/services/logging.md](backend/services/logging.md)
 **"How do BookDate card stack animations work?"** → [features/bookdate-animations.md](features/bookdate-animations.md)
 **"How does Audiobookshelf integration work?"** → `src/lib/services/audiobookshelf/api.ts`, `src/lib/services/library/AudiobookshelfLibraryService.ts`
+**"How do I tag books by requester?"** → [features/requester-tags.md](features/requester-tags.md)
+**"How do I scope ABS library access per user?"** → [features/requester-tags.md](features/requester-tags.md)
 **"How do I use OIDC/Authentik/Keycloak?"** → [backend/services/auth.md](backend/services/auth.md)
 **"How do I switch from Plex to Audiobookshelf?"** → Setup wizard (re-run setup with different backend mode)
 **"How does library thumbnail caching work?"** → [features/library-thumbnail-cache.md](features/library-thumbnail-cache.md)

--- a/documentation/features/requester-tags.md
+++ b/documentation/features/requester-tags.md
@@ -1,0 +1,34 @@
+# Requester Tags (Audiobookshelf)
+
+**Status:** ✅ Implemented | ABS-only | Tags matched items with `req:<username>`
+
+## Overview
+When enabled, RMAB writes a `req:<sanitized_username>` tag onto each Audiobookshelf item it matches to a completed request. Because every request method (Web UI, Discord, API) produces a `Request` with a `user`, tagging at match time covers all of them through one code path. ABS supports per-user library filtering by tag, so admins can scope what each user sees.
+
+## Key Details
+- **Setting:** `audiobookshelf.tag_requester` (boolean, default `false`) — checkbox in Library tab → Audiobookshelf section.
+- **Tag format:** `req:` + username lowercased, trimmed, spaces→`_`, chars outside `[a-z0-9_-]` stripped. `John Smith` → `req:john_smith`.
+- **Merge, never overwrite:** GET `media.tags`, union with new tags (dedupe), PATCH back. Preserves manual tags (`nsfw`) and other requesters' `req:` tags. Skips the write if unchanged.
+- **Apply points:** both match loops that flip a request to `available` — `scan-plex.processor.ts` (full scan) and `plex-recently-added.processor.ts` (scheduled recently-added check). Guarded by `tagRequester && backendMode === 'audiobookshelf' && match.plexGuid && username`. Both paths must tag; a request matched by either is otherwise excluded from the other.
+- **Backfill:** false→true toggle of the setting enqueues a one-time `backfill_requester_tags` job that tags existing `available` audiobook requests with `absItemId` set.
+- **Best-effort:** tagging never throws; failures are logged and the scan/backfill continues.
+
+## ABS API (`src/lib/services/audiobookshelf/api.ts`)
+- `formatRequesterTag(username): string` — sanitized `req:<username>`.
+- `addABSItemTags(itemId, tagsToAdd: string[]): Promise<void>` — GET `media.tags`, merge, PATCH `/items/:id/media` `{ tags }`. Best-effort.
+
+## Job
+- Type: `backfill_requester_tags` (registered in `job-queue.service.ts`, concurrency 1).
+- Enqueue: `addBackfillRequesterTagsJob()`, triggered from the ABS settings PUT route on false→true.
+- Processor: `src/lib/processors/backfill-requester-tags.processor.ts` — queries `status='available'`, `type='audiobook'`, `deletedAt=null`, `audiobook.absItemId != null`; calls `addABSItemTags` per request.
+
+## Scope / Notes
+- **Plex backend:** out of scope; ABS-only.
+- **Delete:** no tag removal needed — cascading `/delete` removes the whole ABS item.
+- **Idempotency:** merge dedupes; `available` requests are excluded from the match loop, so no repeat API calls outside the one-time backfill.
+- **Empty/unknown usernames:** skipped.
+- **Sanitization collisions:** two usernames could map to one tag (acceptable, low risk).
+
+## Related
+- [settings-pages.md](../settings-pages.md#requester-tagging-audiobookshelf-only)
+- `src/lib/processors/scan-plex.processor.ts`, `src/lib/processors/plex-recently-added.processor.ts`, `src/lib/services/audiobookshelf/api.ts`

--- a/documentation/settings-pages.md
+++ b/documentation/settings-pages.md
@@ -222,6 +222,20 @@ src/app/admin/settings/
 - When disabled: User relies on media server's filesystem watcher or manual scans
 - Error handling: Scan failures logged but don't fail organize job (graceful degradation)
 
+## Requester Tagging (Audiobookshelf only)
+
+**Purpose:** Tag each matched ABS item with `req:<username>` so admins can scope per-user library access by tag. See: [features/requester-tags.md](features/requester-tags.md).
+
+**Configuration:**
+- Key: `audiobookshelf.tag_requester` (boolean, default: false)
+- UI: Checkbox in Audiobookshelf settings section (Library tab), below the scan-trigger toggle
+
+**Behavior:**
+- At match time (`scan-plex.processor.ts`), when a request flips to `available` and ABS item ID + username are present, RMAB merges `req:<username>` into the item's `media.tags` (best-effort, never fails the scan).
+- Tag format: `req:` + username lowercased, trimmed, spaces→`_`, chars outside `[a-z0-9_-]` stripped.
+- Merge (not overwrite): GET current tags, union, PATCH back — preserves manual tags and other requesters' tags.
+- Toggling false→true enqueues a one-time `backfill_requester_tags` job that tags existing available requests.
+
 ## Plex Format Coercion
 
 **Purpose:** Rename audiobook files to Plex-recognized extensions (`.mp4` → `.m4b`, single-file `.m4a` → `.m4b`) before the library scan. Prevents Plex silently ignoring `.mp4` audiobooks. Rename-only — no transcoding. See: [phase3/file-organization.md](phase3/file-organization.md#plex-format-coercion).

--- a/src/app/admin/settings/lib/types.ts
+++ b/src/app/admin/settings/lib/types.ts
@@ -40,6 +40,12 @@ export interface AudiobookshelfSettings {
   apiToken: string;
   libraryId: string;
   triggerScanAfterImport: boolean;
+  /**
+   * When true, RMAB writes a `req:<username>` tag onto each ABS item it matches
+   * to a completed request. Lets admins scope per-user library access by tag.
+   * Backing config key: `audiobookshelf.tag_requester`.
+   */
+  tagRequester: boolean;
 }
 
 /**

--- a/src/app/admin/settings/tabs/LibraryTab/AudiobookshelfSection.tsx
+++ b/src/app/admin/settings/tabs/LibraryTab/AudiobookshelfSection.tsx
@@ -58,6 +58,13 @@ export function AudiobookshelfSection({
     });
   };
 
+  const handleTagRequesterChange = (tagRequester: boolean) => {
+    onChange({
+      ...settings,
+      audiobookshelf: { ...settings.audiobookshelf, tagRequester },
+    });
+  };
+
   const handleAudibleRegionChange = (audibleRegion: string) => {
     onChange({
       ...settings,
@@ -143,6 +150,28 @@ export function AudiobookshelfSection({
               Automatically triggers Audiobookshelf to scan its filesystem after organizing downloaded files.
               Only enable this if you have Audiobookshelf's filesystem watcher (automatic scanning) disabled.
               Most users should leave this disabled and rely on Audiobookshelf's built-in automatic detection.
+            </p>
+          </div>
+        </label>
+      </div>
+
+      <div className="space-y-2">
+        <label className="flex items-start gap-3 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={settings.audiobookshelf.tagRequester}
+            onChange={(e) => handleTagRequesterChange(e.target.checked)}
+            className="mt-1 h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800"
+          />
+          <div className="flex-1">
+            <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
+              Tag items with the requester's username
+            </span>
+            <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+              When a requested audiobook becomes available, RMAB adds a <code>req:&lt;username&gt;</code> tag
+              to the matched Audiobookshelf item. Tags are merged, so multiple requesters and manual tags are
+              preserved. Audiobookshelf can use these tags to filter what each user sees in their library.
+              Enabling this kicks off a one-time backfill of already-available requests.
             </p>
           </div>
         </label>

--- a/src/app/api/admin/settings/audiobookshelf/route.ts
+++ b/src/app/api/admin/settings/audiobookshelf/route.ts
@@ -15,16 +15,22 @@ export async function PUT(request: NextRequest) {
     return requireAdmin(req, async () => {
       try {
         const body = await request.json();
-        const { serverUrl, apiToken, libraryId, triggerScanAfterImport } = body;
+        const { serverUrl, apiToken, libraryId, triggerScanAfterImport, tagRequester } = body;
 
         const { getConfigService } = await import('@/lib/services/config.service');
         const configService = getConfigService();
+
+        // Detect a false→true transition of the requester-tagging setting so we
+        // can backfill tags onto already-available requests one time.
+        const previousTagRequester = (await configService.get('audiobookshelf.tag_requester')) === 'true';
+        const newTagRequester = tagRequester === true;
 
         // Build updates array, skipping masked values
         const updates: ConfigUpdate[] = [
           { key: 'audiobookshelf.server_url', value: serverUrl || '' },
           { key: 'audiobookshelf.library_id', value: libraryId || '' },
           { key: 'audiobookshelf.trigger_scan_after_import', value: triggerScanAfterImport === true ? 'true' : 'false' },
+          { key: 'audiobookshelf.tag_requester', value: newTagRequester ? 'true' : 'false' },
         ];
 
         // Only update API token if it's not the masked placeholder
@@ -38,6 +44,18 @@ export async function PUT(request: NextRequest) {
 
         // Update configuration
         await configService.setMany(updates);
+
+        // On a false→true toggle, enqueue a one-time backfill that tags existing
+        // available audiobook requests with their requester's `req:<username>` tag.
+        if (!previousTagRequester && newTagRequester) {
+          try {
+            const { getJobQueueService } = await import('@/lib/services/job-queue.service');
+            await getJobQueueService().addBackfillRequesterTagsJob();
+            logger.info('Enqueued requester-tag backfill job (setting toggled on)');
+          } catch (error) {
+            logger.error('Failed to enqueue requester-tag backfill job', { error: error instanceof Error ? error.message : String(error) });
+          }
+        }
 
         return NextResponse.json({
           success: true,

--- a/src/app/api/admin/settings/route.ts
+++ b/src/app/api/admin/settings/route.ts
@@ -57,6 +57,7 @@ export async function GET(request: NextRequest) {
         apiToken: maskValue('api_token', configMap.get('audiobookshelf.api_token')),
         libraryId: configMap.get('audiobookshelf.library_id') || '',
         triggerScanAfterImport: configMap.get('audiobookshelf.trigger_scan_after_import') === 'true',
+        tagRequester: configMap.get('audiobookshelf.tag_requester') === 'true',
       },
       oidc: {
         enabled: configMap.get('oidc.enabled') === 'true',

--- a/src/lib/processors/backfill-requester-tags.processor.ts
+++ b/src/lib/processors/backfill-requester-tags.processor.ts
@@ -1,0 +1,86 @@
+/**
+ * Component: Backfill Requester Tags Processor
+ * Documentation: documentation/features/requester-tags.md
+ *
+ * One-time backfill triggered when the ABS "tag requester" setting is toggled on.
+ * Tags every already-available audiobook request's matched ABS item with the
+ * requester's `req:<username>` tag. Tags are merged, so existing tags survive.
+ */
+
+import { prisma } from '../db';
+import { RMABLogger } from '../utils/logger';
+
+export interface BackfillRequesterTagsPayload {
+  jobId?: string;
+  scheduledJobId?: string;
+}
+
+export async function processBackfillRequesterTags(payload: BackfillRequesterTagsPayload): Promise<any> {
+  const { jobId } = payload;
+  const logger = RMABLogger.forJob(jobId, 'BackfillRequesterTags');
+
+  logger.info('Starting requester-tag backfill for available audiobook requests...');
+
+  try {
+    const { getConfigService } = await import('../services/config.service');
+    const configService = getConfigService();
+
+    // Only meaningful for the Audiobookshelf backend.
+    const backendMode = await configService.getBackendMode();
+    if (backendMode !== 'audiobookshelf') {
+      logger.warn(`Backend mode is '${backendMode}', not audiobookshelf — skipping backfill`);
+      return { success: false, message: 'Not in Audiobookshelf mode', skipped: true };
+    }
+
+    const { addABSItemTags, formatRequesterTag } = await import('../services/audiobookshelf/api');
+
+    // All available audiobook requests whose matched ABS item ID is known.
+    const requests = await prisma.request.findMany({
+      where: {
+        status: 'available',
+        type: 'audiobook',
+        deletedAt: null,
+        audiobook: { absItemId: { not: null } },
+      },
+      include: {
+        audiobook: { select: { absItemId: true } },
+        user: { select: { plexUsername: true } },
+      },
+    });
+
+    logger.info(`Found ${requests.length} available requests to backfill`);
+
+    let tagged = 0;
+    let skipped = 0;
+
+    for (const request of requests) {
+      const itemId = request.audiobook.absItemId;
+      const username = request.user.plexUsername;
+      const tag = username ? formatRequesterTag(username) : '';
+
+      // Skip when we can't form a usable tag (missing item ID, or a username
+      // that sanitizes to nothing — see formatRequesterTag).
+      if (!itemId || !tag) {
+        skipped++;
+        continue;
+      }
+
+      // Best-effort; addABSItemTags never throws and merges tags.
+      await addABSItemTags(itemId, [tag]);
+      tagged++;
+    }
+
+    logger.info(`Requester-tag backfill complete`, { tagged, skipped, total: requests.length });
+
+    return {
+      success: true,
+      message: `Backfilled requester tags (${tagged} tagged, ${skipped} skipped)`,
+      tagged,
+      skipped,
+      total: requests.length,
+    };
+  } catch (error) {
+    logger.error('Requester-tag backfill failed', { error: error instanceof Error ? error.message : String(error) });
+    throw error;
+  }
+}

--- a/src/lib/processors/plex-recently-added.processor.ts
+++ b/src/lib/processors/plex-recently-added.processor.ts
@@ -26,6 +26,10 @@ export async function processPlexRecentlyAddedCheck(payload: PlexRecentlyAddedPa
   const backendMode = await configService.getBackendMode();
   logger.info(`Backend mode: ${backendMode}`);
 
+  // Whether to tag matched ABS items with the requester's `req:<username>` tag.
+  // Read once per run; only meaningful for the Audiobookshelf backend.
+  const tagRequester = (await configService.get('audiobookshelf.tag_requester')) === 'true';
+
   // Validate configuration based on backend mode
   if (backendMode === 'audiobookshelf') {
     const absConfig = await configService.getMany([
@@ -333,6 +337,18 @@ export async function processPlexRecentlyAddedCheck(payload: PlexRecentlyAddedPa
             });
 
             matchedDownloads++;
+
+            // Tag the matched ABS item with the requester's username (best-effort).
+            // Mirrors scan-plex.processor.ts — this is the second match path that
+            // flips a request to 'available', so it must tag too.
+            const username = request.user.plexUsername;
+            if (tagRequester && backendMode === 'audiobookshelf' && match.plexGuid && username) {
+              const { addABSItemTags, formatRequesterTag } = await import('../services/audiobookshelf/api');
+              const tag = formatRequesterTag(username);
+              if (tag) {
+                await addABSItemTags(match.plexGuid, [tag]);
+              }
+            }
 
             // Note: Audiobookshelf metadata matching is handled in the file hash phase above
             // Items without ASIN get file-hash-matched ASIN, items with ASIN already have correct metadata

--- a/src/lib/processors/scan-plex.processor.ts
+++ b/src/lib/processors/scan-plex.processor.ts
@@ -31,6 +31,10 @@ export async function processScanPlex(payload: ScanPlexPayload): Promise<any> {
     const backendMode = await configService.getBackendMode();
     const thumbnailCacheService = getThumbnailCacheService();
 
+    // Whether to tag matched ABS items with the requester's `req:<username>` tag.
+    // Read once per scan; only meaningful for the Audiobookshelf backend.
+    const tagRequester = (await configService.get('audiobookshelf.tag_requester')) === 'true';
+
     logger.info(`Backend mode: ${backendMode}`);
 
     // 2. Get configured library ID
@@ -522,6 +526,18 @@ export async function processScanPlex(payload: ScanPlexPayload): Promise<any> {
           });
 
           matchedCount++;
+
+          // Tag the matched ABS item with the requester's username (best-effort).
+          // Only for the ABS backend, when enabled, and when we have both an item
+          // ID and a username. Tags are merged so other tags are preserved.
+          const username = request.user.plexUsername;
+          if (tagRequester && backendMode === 'audiobookshelf' && match.plexGuid && username) {
+            const { addABSItemTags, formatRequesterTag } = await import('../services/audiobookshelf/api');
+            const tag = formatRequesterTag(username);
+            if (tag) {
+              await addABSItemTags(match.plexGuid, [tag]);
+            }
+          }
 
           // Note: Audiobookshelf metadata matching is handled in the file hash phase above
           // Items without ASIN get file-hash-matched ASIN, items with ASIN already have correct metadata

--- a/src/lib/services/audiobookshelf/api.ts
+++ b/src/lib/services/audiobookshelf/api.ts
@@ -22,7 +22,7 @@ function mapRegionToABSProvider(region: AudibleRegion): string {
 }
 
 interface ABSRequestOptions {
-  method?: 'GET' | 'POST' | 'PUT' | 'DELETE';
+  method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
   body?: any;
 }
 
@@ -168,6 +168,69 @@ export async function triggerABSItemMatch(itemId: string, asin?: string) {
   } catch (error) {
     // Don't throw - matching is best-effort, scan should continue even if match fails
     logger.error(`Failed to trigger match for item ${itemId}`, { error: error instanceof Error ? error.message : String(error) });
+  }
+}
+
+/**
+ * Format a requester tag from a username.
+ * Lowercases, trims, converts spaces to underscores, and strips any character
+ * outside [a-z0-9_-]. Example: "John Smith" -> "req:john_smith".
+ *
+ * Returns '' when the username sanitizes to nothing (e.g. all-symbol or
+ * non-Latin usernames). Callers MUST skip empty results — otherwise every such
+ * user would collapse onto a single bare `req:` tag, exposing their libraries
+ * to each other. The whole point of the tag is per-user scoping.
+ *
+ * @param username - The requester's username
+ * @returns The sanitized `req:<username>` tag, or '' if nothing usable remains
+ */
+export function formatRequesterTag(username: string): string {
+  const sanitized = username
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, '_')
+    .replace(/[^a-z0-9_-]/g, '');
+  return sanitized ? `req:${sanitized}` : '';
+}
+
+/**
+ * Add tags to an Audiobookshelf library item, merging with any existing tags.
+ * Best-effort: never throws (logs on failure), mirroring triggerABSItemMatch.
+ *
+ * ABS's PATCH /items/:id/media replaces the entire tags array, so we GET the
+ * current media.tags, union with the new tags (dedupe), and PATCH back. This
+ * preserves manual tags (e.g. `nsfw`) and other requesters' `req:` tags.
+ *
+ * @param itemId - The Audiobookshelf item ID
+ * @param tagsToAdd - Tags to add to the item
+ */
+export async function addABSItemTags(itemId: string, tagsToAdd: string[]): Promise<void> {
+  try {
+    // Drop empty/blank tags defensively — never write a bare/whitespace tag.
+    const cleanTags = tagsToAdd.filter((t) => t && t.trim().length > 0);
+    if (cleanTags.length === 0) {
+      return;
+    }
+
+    const item = await getABSItem(itemId);
+    const currentTags: string[] = Array.isArray(item?.media?.tags) ? item.media.tags : [];
+
+    const merged = Array.from(new Set([...currentTags, ...cleanTags]));
+
+    // Skip the write if nothing would change
+    if (merged.length === currentTags.length) {
+      return;
+    }
+
+    await absRequest(`/items/${itemId}/media`, {
+      method: 'PATCH',
+      body: { tags: merged },
+    });
+
+    logger.info(`Tagged ABS item ${itemId}`, { added: cleanTags });
+  } catch (error) {
+    // Don't throw - tagging is best-effort, scan/backfill should continue
+    logger.error(`Failed to tag ABS item ${itemId}`, { error: error instanceof Error ? error.message : String(error) });
   }
 }
 

--- a/src/lib/services/job-queue.service.ts
+++ b/src/lib/services/job-queue.service.ts
@@ -29,6 +29,7 @@ export type JobType =
   | 'monitor_rss_feeds'
   | 'sync_reading_shelves'
   | 'check_watched_lists'
+  | 'backfill_requester_tags'
   | 'send_notification'
   // Ebook-specific job types
   | 'search_ebook'
@@ -120,6 +121,10 @@ export interface SyncShelvesPayload extends JobPayload {
   shelfType?: 'goodreads' | 'hardcover';
   userId?: string;
   maxLookupsPerShelf?: number;
+}
+
+export interface BackfillRequesterTagsPayload extends JobPayload {
+  scheduledJobId?: string;
 }
 
 export interface CheckWatchedListsPayload extends JobPayload {
@@ -413,6 +418,12 @@ export class JobQueueService {
       const { processCheckWatchedLists } = await import('../processors/check-watched-lists.processor');
       const payloadWithJobId = await this.ensureJobRecord(job, 'check_watched_lists');
       return await processCheckWatchedLists(payloadWithJobId);
+    });
+
+    this.queue.process('backfill_requester_tags', 1, async (job: BullJob<BackfillRequesterTagsPayload>) => {
+      const { processBackfillRequesterTags } = await import('../processors/backfill-requester-tags.processor');
+      const payloadWithJobId = await this.ensureJobRecord(job, 'backfill_requester_tags');
+      return await processBackfillRequesterTags(payloadWithJobId);
     });
 
     // Send notification processor
@@ -851,6 +862,23 @@ export class JobQueueService {
       } as CheckWatchedListsPayload,
       {
         priority: 8, // Higher than scheduled (7) since user-initiated
+      }
+    );
+  }
+
+  /**
+   * Add backfill requester tags job.
+   * Tags already-available ABS audiobook requests with their `req:<username>` tag.
+   * Triggered when the ABS "tag requester" setting is toggled on.
+   */
+  async addBackfillRequesterTagsJob(scheduledJobId?: string): Promise<string> {
+    return await this.addJob(
+      'backfill_requester_tags',
+      {
+        scheduledJobId,
+      } as BackfillRequesterTagsPayload,
+      {
+        priority: 6,
       }
     );
   }

--- a/tests/api/admin-settings-core.routes.test.ts
+++ b/tests/api/admin-settings-core.routes.test.ts
@@ -12,6 +12,7 @@ const prismaMock = createPrismaMock();
 const requireAuthMock = vi.hoisted(() => vi.fn());
 const requireAdminMock = vi.hoisted(() => vi.fn());
 const configServiceMock = vi.hoisted(() => ({
+  get: vi.fn(),
   setMany: vi.fn(),
   clearCache: vi.fn(),
 }));
@@ -20,6 +21,7 @@ const audibleServiceMock = vi.hoisted(() => ({
 }));
 const jobQueueMock = vi.hoisted(() => ({
   addAudibleRefreshJob: vi.fn(),
+  addBackfillRequesterTagsJob: vi.fn(),
 }));
 const plexServiceMock = vi.hoisted(() => ({
   testConnection: vi.fn(),
@@ -393,6 +395,50 @@ describe('Admin settings core routes', () => {
 
     expect(payload.success).toBe(true);
     expect(configServiceMock.setMany).toHaveBeenCalled();
+  });
+
+  it('enqueues a backfill job when tagRequester toggles false→true', async () => {
+    // Previous stored value is 'false' (off)
+    configServiceMock.get.mockResolvedValue('false');
+
+    const request = {
+      json: vi.fn().mockResolvedValue({
+        serverUrl: 'http://abs',
+        apiToken: 'token',
+        libraryId: 'lib',
+        triggerScanAfterImport: false,
+        tagRequester: true,
+      }),
+    };
+
+    const { PUT } = await import('@/app/api/admin/settings/audiobookshelf/route');
+    const response = await PUT(request as any);
+    const payload = await response.json();
+
+    expect(payload.success).toBe(true);
+    expect(jobQueueMock.addBackfillRequesterTagsJob).toHaveBeenCalled();
+  });
+
+  it('does not enqueue a backfill job when tagRequester was already on', async () => {
+    // Previous stored value is 'true' (already on)
+    configServiceMock.get.mockResolvedValue('true');
+
+    const request = {
+      json: vi.fn().mockResolvedValue({
+        serverUrl: 'http://abs',
+        apiToken: 'token',
+        libraryId: 'lib',
+        triggerScanAfterImport: false,
+        tagRequester: true,
+      }),
+    };
+
+    const { PUT } = await import('@/app/api/admin/settings/audiobookshelf/route');
+    const response = await PUT(request as any);
+    const payload = await response.json();
+
+    expect(payload.success).toBe(true);
+    expect(jobQueueMock.addBackfillRequesterTagsJob).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/processors/backfill-requester-tags.processor.test.ts
+++ b/tests/processors/backfill-requester-tags.processor.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Component: Backfill Requester Tags Processor Tests
+ * Documentation: documentation/features/requester-tags.md
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createPrismaMock } from '../helpers/prisma';
+
+const prismaMock = createPrismaMock();
+const configMock = vi.hoisted(() => ({
+  getBackendMode: vi.fn(),
+}));
+
+vi.mock('@/lib/db', () => ({
+  prisma: prismaMock,
+}));
+
+vi.mock('@/lib/services/config.service', () => ({
+  getConfigService: () => configMock,
+}));
+
+vi.mock('@/lib/services/audiobookshelf/api', () => ({
+  addABSItemTags: vi.fn(() => Promise.resolve()),
+  formatRequesterTag: (username: string) => {
+    const sanitized = username.trim().toLowerCase().replace(/\s+/g, '_').replace(/[^a-z0-9_-]/g, '');
+    return sanitized ? `req:${sanitized}` : '';
+  },
+}));
+
+describe('processBackfillRequesterTags', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('skips entirely when not in Audiobookshelf mode', async () => {
+    configMock.getBackendMode.mockResolvedValue('plex');
+
+    const { processBackfillRequesterTags } = await import('@/lib/processors/backfill-requester-tags.processor');
+    const result = await processBackfillRequesterTags({ jobId: 'job-1' });
+
+    expect(result.skipped).toBe(true);
+    expect(prismaMock.request.findMany).not.toHaveBeenCalled();
+  });
+
+  it('tags each eligible available request and skips unusable ones', async () => {
+    configMock.getBackendMode.mockResolvedValue('audiobookshelf');
+
+    prismaMock.request.findMany.mockResolvedValue([
+      { audiobook: { absItemId: 'abs-1' }, user: { plexUsername: 'guggs' } },
+      { audiobook: { absItemId: 'abs-2' }, user: { plexUsername: 'John Smith' } },
+      // Unusable: username sanitizes to nothing
+      { audiobook: { absItemId: 'abs-3' }, user: { plexUsername: '李雷' } },
+      // Unusable: no username
+      { audiobook: { absItemId: 'abs-4' }, user: { plexUsername: null } },
+    ] as any);
+
+    const absApi = await import('@/lib/services/audiobookshelf/api');
+
+    const { processBackfillRequesterTags } = await import('@/lib/processors/backfill-requester-tags.processor');
+    const result = await processBackfillRequesterTags({ jobId: 'job-2' });
+
+    expect(result.tagged).toBe(2);
+    expect(result.skipped).toBe(2);
+    expect(result.total).toBe(4);
+    expect(absApi.addABSItemTags).toHaveBeenCalledTimes(2);
+    expect(absApi.addABSItemTags).toHaveBeenCalledWith('abs-1', ['req:guggs']);
+    expect(absApi.addABSItemTags).toHaveBeenCalledWith('abs-2', ['req:john_smith']);
+  });
+
+  it('queries only non-deleted available audiobook requests with an ABS item ID', async () => {
+    configMock.getBackendMode.mockResolvedValue('audiobookshelf');
+    prismaMock.request.findMany.mockResolvedValue([]);
+
+    const { processBackfillRequesterTags } = await import('@/lib/processors/backfill-requester-tags.processor');
+    await processBackfillRequesterTags({ jobId: 'job-3' });
+
+    expect(prismaMock.request.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          status: 'available',
+          type: 'audiobook',
+          deletedAt: null,
+          audiobook: { absItemId: { not: null } },
+        }),
+      })
+    );
+  });
+});

--- a/tests/processors/plex-recently-added.processor.test.ts
+++ b/tests/processors/plex-recently-added.processor.test.ts
@@ -46,6 +46,8 @@ vi.mock('@/lib/utils/audiobook-matcher', () => ({
 vi.mock('@/lib/services/audiobookshelf/api', () => ({
   triggerABSItemMatch: vi.fn(),
   getABSItem: vi.fn(),
+  addABSItemTags: vi.fn(() => Promise.resolve()),
+  formatRequesterTag: (username: string) => `req:${username.toLowerCase()}`,
 }));
 
 vi.mock('@/lib/services/thumbnail-cache.service', () => ({
@@ -266,6 +268,71 @@ describe('processPlexRecentlyAddedCheck', () => {
     );
     // Should NOT trigger metadata match - items already have metadata from ABS
     expect(absApi.triggerABSItemMatch).not.toHaveBeenCalled();
+  });
+
+  it('tags the matched ABS item with the requester when tag_requester is enabled', async () => {
+    const matcher = await import('@/lib/utils/audiobook-matcher');
+    const absApi = await import('@/lib/services/audiobookshelf/api');
+
+    configMock.getBackendMode.mockResolvedValue('audiobookshelf');
+    configMock.getMany.mockResolvedValue({
+      'audiobookshelf.server_url': 'http://abs',
+      'audiobookshelf.api_token': 'token',
+      'audiobookshelf.library_id': 'abs-lib',
+    });
+    // Library ID lookup + tag_requester flag
+    configMock.get.mockImplementation(async (key: string) =>
+      key === 'audiobookshelf.tag_requester' ? 'true' : 'abs-lib'
+    );
+
+    libraryServiceMock.getCoverCachingParams.mockResolvedValue({
+      backendBaseUrl: 'http://abs',
+      authToken: 'token',
+      backendMode: 'audiobookshelf',
+    });
+    thumbnailCacheServiceMock.cacheLibraryThumbnail.mockResolvedValue('/app/cache/library/test.jpg');
+
+    libraryServiceMock.getRecentlyAdded.mockResolvedValue([
+      {
+        id: 'abs-1',
+        externalId: 'abs-item-1',
+        title: 'New ABS Item',
+        author: 'Author A',
+        asin: 'ASIN-ABS',
+        addedAt: new Date(),
+      },
+    ]);
+    prismaMock.plexLibrary.findUnique.mockResolvedValue(null);
+    prismaMock.plexLibrary.create.mockResolvedValue({});
+
+    prismaMock.request.findMany.mockResolvedValue([
+      {
+        id: 'req-1',
+        status: 'downloaded',
+        audiobook: {
+          id: 'ab-1',
+          title: 'Match Me',
+          author: 'Author A',
+          narrator: 'Narrator A',
+          audibleAsin: 'ASIN-ABS',
+        },
+        user: { plexUsername: 'guggs' },
+      },
+    ] as any);
+
+    (matcher.findPlexMatch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      plexGuid: 'abs-item-1',
+      plexRatingKey: 'rating-abs',
+      title: 'Match Me',
+      author: 'Author A',
+    });
+    prismaMock.audiobook.update.mockResolvedValue({});
+    prismaMock.request.update.mockResolvedValue({});
+
+    const { processPlexRecentlyAddedCheck } = await import('@/lib/processors/plex-recently-added.processor');
+    await processPlexRecentlyAddedCheck({ jobId: 'job-tag' });
+
+    expect(absApi.addABSItemTags).toHaveBeenCalledWith('abs-item-1', ['req:guggs']);
   });
 });
 

--- a/tests/processors/scan-plex.processor.test.ts
+++ b/tests/processors/scan-plex.processor.test.ts
@@ -34,6 +34,8 @@ vi.mock('@/lib/services/job-queue.service', () => ({
 vi.mock('@/lib/services/audiobookshelf/api', () => ({
   triggerABSItemMatch: vi.fn(),
   getABSItem: vi.fn(),
+  addABSItemTags: vi.fn(() => Promise.resolve()),
+  formatRequesterTag: (username: string) => `req:${username.toLowerCase()}`,
 }));
 
 vi.mock('@/lib/db', () => ({
@@ -370,6 +372,56 @@ describe('processScanPlex', () => {
     );
     // Should NOT trigger metadata match - items with ASIN already have correct metadata
     expect(absApi.triggerABSItemMatch).not.toHaveBeenCalled();
+  });
+
+  it('tags the matched ABS item with the requester when tag_requester is enabled', async () => {
+    configMock.getBackendMode.mockResolvedValue('audiobookshelf');
+    // Library ID lookup + tag_requester flag
+    configMock.get.mockImplementation(async (key: string) =>
+      key === 'audiobookshelf.tag_requester' ? 'true' : 'abs-lib'
+    );
+
+    libraryServiceMock.getCoverCachingParams.mockResolvedValue({
+      backendBaseUrl: 'http://abs',
+      authToken: 'token',
+      backendMode: 'audiobookshelf',
+    });
+    thumbnailCacheServiceMock.cacheLibraryThumbnail.mockResolvedValue('/app/cache/library/test.jpg');
+    libraryServiceMock.getLibraryItems.mockResolvedValue([]);
+
+    prismaMock.plexLibrary.findMany.mockResolvedValue([]);
+    prismaMock.audiobook.findMany.mockResolvedValue([]);
+    prismaMock.request.findMany.mockResolvedValue([
+      {
+        id: 'req-abs',
+        status: 'downloaded',
+        audiobook: {
+          id: 'abs-audio',
+          title: 'ABS Title',
+          author: 'ABS Author',
+          narrator: 'Narrator',
+          audibleAsin: 'ASIN123',
+        },
+        user: { plexUsername: 'guggs' },
+      },
+    ] as any);
+    prismaMock.audiobook.update.mockResolvedValue({});
+    prismaMock.request.update.mockResolvedValue({});
+
+    const matcher = await import('@/lib/utils/audiobook-matcher');
+    (matcher.findPlexMatch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      plexGuid: 'abs-item-1',
+      plexRatingKey: 'rating-abs',
+      title: 'ABS Title',
+      author: 'ABS Author',
+    });
+
+    const absApi = await import('@/lib/services/audiobookshelf/api');
+
+    const { processScanPlex } = await import('@/lib/processors/scan-plex.processor');
+    await processScanPlex({ jobId: 'job-tag' });
+
+    expect(absApi.addABSItemTags).toHaveBeenCalledWith('abs-item-1', ['req:guggs']);
   });
 
   it('uses file hash matching for ABS items without ASIN', async () => {

--- a/tests/services/audiobookshelf-api.test.ts
+++ b/tests/services/audiobookshelf-api.test.ts
@@ -6,7 +6,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   absRequest,
+  addABSItemTags,
   deleteABSItem,
+  formatRequesterTag,
   getABSLibraries,
   getABSLibraryItems,
   getABSRecentItems,
@@ -296,5 +298,94 @@ describe('Audiobookshelf API client', () => {
     });
 
     await expect(deleteABSItem('item-1')).rejects.toThrow('ABS API error: 500 Boom');
+  });
+
+  it('formats requester tags by sanitizing the username', () => {
+    expect(formatRequesterTag('John Smith')).toBe('req:john_smith');
+    expect(formatRequesterTag('  Jane.Doe!  ')).toBe('req:janedoe');
+    expect(formatRequesterTag('user-123_ok')).toBe('req:user-123_ok');
+    expect(formatRequesterTag('ALLCAPS')).toBe('req:allcaps');
+  });
+
+  it('returns an empty string when the username sanitizes to nothing', () => {
+    // All-symbol and non-Latin usernames strip down to nothing — must NOT
+    // collapse onto a shared bare `req:` tag.
+    expect(formatRequesterTag('!!!')).toBe('');
+    expect(formatRequesterTag('   ')).toBe('');
+    expect(formatRequesterTag('李雷')).toBe('');
+    expect(formatRequesterTag('')).toBe('');
+  });
+
+  it('does not write when all tags are empty/blank', async () => {
+    configServiceMock.get.mockImplementation(async (key: string) => {
+      if (key === 'audiobookshelf.server_url') return 'http://abs';
+      if (key === 'audiobookshelf.api_token') return 'token';
+      return null;
+    });
+
+    await addABSItemTags('item-1', ['', '   ']);
+
+    // Never even fetches the item — nothing usable to add.
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('merges new tags with existing ABS item tags via PATCH', async () => {
+    configServiceMock.get.mockImplementation(async (key: string) => {
+      if (key === 'audiobookshelf.server_url') return 'http://abs';
+      if (key === 'audiobookshelf.api_token') return 'token';
+      return null;
+    });
+    // First call: GET item with existing tags. Second call: PATCH media.
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ media: { tags: ['nsfw', 'req:other'] } }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({}),
+      });
+
+    await addABSItemTags('item-1', ['req:john']);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const patchCall = fetchMock.mock.calls[1];
+    expect(patchCall[0]).toBe('http://abs/api/items/item-1/media');
+    expect(patchCall[1].method).toBe('PATCH');
+    expect(JSON.parse(patchCall[1].body)).toEqual({
+      tags: ['nsfw', 'req:other', 'req:john'],
+    });
+  });
+
+  it('skips the PATCH when all tags already exist', async () => {
+    configServiceMock.get.mockImplementation(async (key: string) => {
+      if (key === 'audiobookshelf.server_url') return 'http://abs';
+      if (key === 'audiobookshelf.api_token') return 'token';
+      return null;
+    });
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ media: { tags: ['req:john'] } }),
+    });
+
+    await addABSItemTags('item-1', ['req:john']);
+
+    // Only the GET happened, no PATCH
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('suppresses errors when tagging fails', async () => {
+    configServiceMock.get.mockImplementation(async (key: string) => {
+      if (key === 'audiobookshelf.server_url') return 'http://abs';
+      if (key === 'audiobookshelf.api_token') return 'token';
+      return null;
+    });
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Boom',
+    });
+
+    await expect(addABSItemTags('item-1', ['req:john'])).resolves.toBeUndefined();
   });
 });


### PR DESCRIPTION
# Tag Audiobookshelf items with `req:<username>` per requester

Closes #229

## Summary
Adds an optional Audiobookshelf-only feature that writes a `req:<sanitized_username>` tag onto each ABS library item when RMAB matches a completed download to a request. Because every request method (Web UI, API, and eventually Discord) produces a `Request` with an associated user, tagging happens at **match time** so all methods are covered by one path. ABS supports per-user library filtering by tag, so admins can scope what each user sees by their `req:<username>` tag. 

The end result is that RMAB will allow Audiobookshelf admins to easily give each user a private library by simply allowing them to see only the requests tagged with their own username (or any number of others).

<img width="780" height="401" alt="New RMAB Checkbox" src="https://github.com/user-attachments/assets/d76c214f-9baf-4587-936c-ba5a6401c0b8" />

<img width="412" height="365" alt="Example ABS User Tag Filter" src="https://github.com/user-attachments/assets/10d73580-4109-4f25-91af-e092466fb462" />


## How it works
- **Setting:** `audiobookshelf.tag_requester` (default off) — new checkbox in Settings → Library → Audiobookshelf.
- **Tag format:** `req:` + username lowercased, trimmed, spaces→`_`, characters outside `[a-z0-9_-]` stripped (`John Smith` → `req:john_smith`). Usernames that sanitize to nothing (all-symbol or non-Latin) are skipped rather than collapsed onto a shared bare `req:` tag.
- **Merge, never overwrite:** GET the item's `media.tags`, union with the new tag (dedupe), `PATCH /items/:id/media` back — so manual tags (e.g. `nsfw`) and other requesters' tags are preserved. Writes are skipped when nothing changes.
- **Applied at both match paths:** `scan-plex.processor.ts` (full scan) and `plex-recently-added.processor.ts` (scheduled recently-added check) — a request matched by either is excluded from the other, so both must tag.
- **Backfill:** toggling the setting false→true enqueues a one-time `backfill_requester_tags` job that tags already-available audiobook requests.
- **Best-effort:** tagging never throws; failures are logged and the scan/backfill continues.

## Changes
- `src/lib/services/audiobookshelf/api.ts` — `PATCH` method, `formatRequesterTag()` (returns `''` for unusable usernames), `addABSItemTags()` (merge + drops empty tags).
- `src/lib/processors/scan-plex.processor.ts`, `src/lib/processors/plex-recently-added.processor.ts` — tag at match time, skipping empty tags.
- `src/lib/processors/backfill-requester-tags.processor.ts` — one-time backfill (new).
- `src/lib/services/job-queue.service.ts` — `backfill_requester_tags` job type, enqueue method, processor registration.
- `src/app/api/admin/settings/route.ts` (GET expose) + `src/app/api/admin/settings/audiobookshelf/route.ts` (save key + false→true backfill trigger).
- `src/app/admin/settings/lib/types.ts` + `.../LibraryTab/AudiobookshelfSection.tsx` — `tagRequester` setting + checkbox.
- Docs: `documentation/features/requester-tags.md` (new), `settings-pages.md`, `TABLEOFCONTENTS.md`.

## Scope / non-goals
- **Plex backend:** out of scope — ABS-only; the setting lives in the ABS section.
- **Tag removal on delete:** not needed — cascading `/delete` removes the whole ABS item.
- **Idempotent:** merge dedupes; `available` requests are excluded from the match loops, so no repeat API calls outside the one-time backfill.
- Empty/unknown usernames are skipped.

## Testing
- Unit tests: ABS client (`formatRequesterTag` incl. empty-sanitize cases, merge / skip-no-op / empty-tag / error), match-time tagging on both the scan and recently-added paths, the backfill processor (query filter + tag/skip counts), and the false→true backfill enqueue.
- `dockerfile.unified` builds clean; full `npm run test` green except for pre-existing unrelated frontend page-test failures (tracked/fixed on `feature/discord-request-tags`).
- Verified live against a real ABS server: backfill + match-time tagging both produce `req:<username>` while preserving existing genre tags.
