### PR TITLE
feat: Configurable minimum-score threshold (+ fix for ranking authors with initials)

### DIFF
--- a/documentation/TABLEOFCONTENTS.md
+++ b/documentation/TABLEOFCONTENTS.md
@@ -64,6 +64,7 @@
 - **Full pipeline overview** → [phase3/README.md](phase3/README.md)
 - **Search via Prowlarr (torrents + NZBs)** → [phase3/prowlarr.md](phase3/prowlarr.md)
 - **Torrent ranking/selection** → [phase3/ranking-algorithm.md](phase3/ranking-algorithm.md)
+- **Minimum score threshold (configurable auto-search strictness)** → [settings-pages.md](settings-pages.md#minimum-score-threshold-indexers-tab), [phase3/ranking-algorithm.md](phase3/ranking-algorithm.md)
 - **Multi-download-client support (qBittorrent, Transmission, SABnzbd, NZBGet)** → [phase3/download-clients.md](phase3/download-clients.md)
 - **qBittorrent integration (torrents)** → [phase3/qbittorrent.md](phase3/qbittorrent.md)
 - **SABnzbd integration (Usenet/NZB)** → [phase3/sabnzbd.md](phase3/sabnzbd.md)

--- a/documentation/phase3/ranking-algorithm.md
+++ b/documentation/phase3/ranking-algorithm.md
@@ -167,8 +167,11 @@ Evaluates and scores torrents to automatically select best audiobook download.
 - Negative modifiers penalize undesired flags (e.g., "Unwanted" at -60%)
   - -60% modifier → 85 base score → -51 penalty = 34 final
 - Dual threshold filtering:
-  - Base score must be ≥ 50 (quality minimum)
-  - Final score must be ≥ 50 (not disqualified by negative bonuses)
+  - Base score must be ≥ minQualityScore (quality minimum; **admin-configurable**, default 50)
+  - Final score must be ≥ minQualityScore (not disqualified by negative bonuses)
+  - Title/author match gate (matchScore > 0) applies independently — even at threshold 0, wrong books are rejected
+  - Configured via Indexers settings tab → keys `indexer.min_quality_score` (audiobook) / `indexer.min_quality_score_ebook` (ebook). See [settings-pages.md](../settings-pages.md#minimum-score-threshold-indexers-tab)
+  - Automatic searches only; manual/interactive searches are never filtered
   - Negative bonuses can disqualify otherwise good torrents
 - Flag extraction from Prowlarr API:
   - `downloadVolumeFactor: 0` → "Freeleech"

--- a/documentation/settings-pages.md
+++ b/documentation/settings-pages.md
@@ -149,6 +149,31 @@ src/app/admin/settings/
 
 **API:** Persisted via `PUT /api/admin/settings/indexer-options`. Saved alongside Prowlarr connection + indexer config when the Indexers tab Save button is clicked.
 
+## Minimum Score Threshold (Indexers tab)
+
+**Purpose:** Optional per-media sliders to tune how strict automatic searches are. The ranking algorithm scores each result 0-100; only results at/above the threshold are downloaded. Section is styled like Indexer Flag Configuration, marked "(Optional)", and lives below the IndexerManagement list.
+
+**Sliders:** range 0-100, default 50, step 1.
+- **Audiobooks** → `indexer.min_quality_score`
+- **E-books** → `indexer.min_quality_score_ebook`
+
+**Semantics:**
+- Higher = stricter (may reject everything → request stuck `awaiting_search`).
+- Lower = more lenient (grabs weaker matches: low seeders, off size).
+- **0** shows a warning: threshold disabled, accepts highest-ranked title/author match regardless of quality.
+- Title/author match gate (matchScore > 0) **always** applies — wrong books rejected even at 0.
+- Manual/interactive searches are **never** filtered.
+
+**Configuration Keys:**
+| Key | Default | Category | Description |
+|-----|---------|----------|-------------|
+| `indexer.min_quality_score` | `50` | `indexer` | Min ranking score for automatic audiobook searches |
+| `indexer.min_quality_score_ebook` | `50` | `indexer` | Min ranking score for automatic ebook searches |
+
+**Read contract (consumed by `search-indexers` / `search-ebook` processors):**
+- `parseInt(value)`, clamped 0-100. Missing/invalid → `50`.
+- Filter: `score >= min && finalScore >= min && breakdown.matchScore >= 1`.
+
 ## Audible Region
 
 **Purpose:** Configure which Audible region to use for metadata and search to ensure accurate ASIN matching with your metadata engine.
@@ -326,9 +351,12 @@ src/app/admin/settings/
 
 **PUT /api/admin/settings/indexer-options**
 - Updates indexer-wide auto-search options
-- Body: `{ skipUnreleased: boolean }` (strict boolean validation)
-- Persists `indexer.skip_unreleased` (category: `indexer`)
+- Body: `{ skipUnreleased: boolean, minQualityScore?: number, minQualityScoreEbook?: number }`
+- `skipUnreleased` strict boolean; score fields optional, validated as integers 0-100
+- Persists `indexer.skip_unreleased`, `indexer.min_quality_score`, `indexer.min_quality_score_ebook` (category: `indexer`)
 - No connection test required
+
+**GET /api/admin/settings/indexer-options** also returns `minQualityScore` and `minQualityScoreEbook` (default 50).
 
 **PUT /api/admin/settings/download-client**
 - Updates download client config

--- a/src/app/admin/settings/lib/helpers.ts
+++ b/src/app/admin/settings/lib/helpers.ts
@@ -120,6 +120,8 @@ export const saveTabSettings = async (
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           skipUnreleased: settings.indexerOptions.skipUnreleased,
+          minQualityScore: settings.indexerOptions.minQualityScore,
+          minQualityScoreEbook: settings.indexerOptions.minQualityScoreEbook,
         }),
       }).then(res => {
         if (!res.ok) throw new Error('Failed to save indexer options');

--- a/src/app/admin/settings/lib/types.ts
+++ b/src/app/admin/settings/lib/types.ts
@@ -88,6 +88,19 @@ export interface IndexerOptionsSettings {
    * Backing config key: `indexer.skip_unreleased`.
    */
   skipUnreleased: boolean;
+  /**
+   * Minimum ranking score (0-100) an audiobook release must reach in automatic
+   * searches to be eligible for download. Default 50. Lower = more lenient
+   * (grabs weaker matches); higher = stricter (may find nothing). The
+   * title/author match gate still applies independently. Manual searches are
+   * unaffected. Backing config key: `indexer.min_quality_score`.
+   */
+  minQualityScore: number;
+  /**
+   * Same as `minQualityScore` but for automatic e-book searches. Default 50.
+   * Backing config key: `indexer.min_quality_score_ebook`.
+   */
+  minQualityScoreEbook: number;
 }
 
 /**

--- a/src/app/admin/settings/tabs/IndexersTab/IndexersTab.tsx
+++ b/src/app/admin/settings/tabs/IndexersTab/IndexersTab.tsx
@@ -11,6 +11,7 @@ import { ConfirmModal } from '@/components/ui/ConfirmModal';
 import { Input } from '@/components/ui/Input';
 import { IndexerManagement } from '@/components/admin/indexers/IndexerManagement';
 import { FlagConfigRow } from '@/components/admin/FlagConfigRow';
+import { MinScoreSlider } from '@/components/admin/MinScoreSlider';
 import { IndexerFlagConfig } from '@/lib/utils/ranking-algorithm';
 import { useIndexersSettings } from './useIndexersSettings';
 import type { Settings, SavedIndexerConfig } from '../../lib/types';
@@ -234,6 +235,51 @@ export function IndexersTab({
             No flag rules configured. Flag bonuses/penalties are optional.
           </p>
         )}
+      </div>
+
+      {/* Minimum Score Threshold Section */}
+      <div className="border-t border-gray-200 dark:border-gray-700 pt-6">
+        <div className="mb-4">
+          <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-2">
+            Minimum Score Threshold (Optional)
+          </h3>
+          <p className="text-sm text-gray-600 dark:text-gray-400">
+            Adjust how strict automatic searches are when accepting a release. The
+            ranking algorithm scores every result 0&ndash;100; only results at or
+            above the threshold are downloaded (default 50). Setting a threshold{' '}
+            <span className="font-medium">too high</span> can reject every result,
+            leaving requests stuck awaiting a re-search; setting it{' '}
+            <span className="font-medium">too low</span> grabs weaker matches (fewer
+            seeders, off-target size). The title/author match check always applies,
+            so wrong books are excluded regardless of these values, and
+            manual/interactive searches are never filtered.
+          </p>
+        </div>
+
+        <div className="space-y-3">
+          <MinScoreSlider
+            label="Audiobooks"
+            mediaLabel="audiobook"
+            value={settings.indexerOptions.minQualityScore}
+            onChange={(minQualityScore) =>
+              onChange({
+                ...settings,
+                indexerOptions: { ...settings.indexerOptions, minQualityScore },
+              })
+            }
+          />
+          <MinScoreSlider
+            label="E-books"
+            mediaLabel="e-book"
+            value={settings.indexerOptions.minQualityScoreEbook}
+            onChange={(minQualityScoreEbook) =>
+              onChange({
+                ...settings,
+                indexerOptions: { ...settings.indexerOptions, minQualityScoreEbook },
+              })
+            }
+          />
+        </div>
       </div>
 
       {/* Confirmation modal for Prowlarr connection change */}

--- a/src/app/api/admin/settings/indexer-options/route.ts
+++ b/src/app/api/admin/settings/indexer-options/route.ts
@@ -15,16 +15,26 @@
  *                 opted out. Workers MUST match this contract:
  *
  *                   const skip = (await config.get('indexer.skip_unreleased')) !== 'false';
+ *
+ * Also manages the automatic-search minimum ranking thresholds:
+ *   - `indexer.min_quality_score`        (audiobook auto-search, default 50)
+ *   - `indexer.min_quality_score_ebook`  (e-book auto-search, default 50)
+ *   Values are integers 0-100. Missing/invalid resolves to 50. Consumed by the
+ *   search-indexers / search-ebook processors. The title/author match gate
+ *   applies independently, so a value of 0 still rejects wrong books.
  */
 
 import { NextRequest, NextResponse } from 'next/server';
 import { requireAuth, requireAdmin, AuthenticatedRequest } from '@/lib/middleware/auth';
 import { getConfigService } from '@/lib/services/config.service';
 import { RMABLogger } from '@/lib/utils/logger';
+import { parseMinQualityScore } from '@/lib/utils/min-quality-score';
 
 const logger = RMABLogger.create('API.Admin.Settings.IndexerOptions');
 
 const CONFIG_KEY = 'indexer.skip_unreleased';
+const MIN_SCORE_KEY = 'indexer.min_quality_score';
+const MIN_SCORE_EBOOK_KEY = 'indexer.min_quality_score_ebook';
 
 /**
  * GET /api/admin/settings/indexer-options
@@ -40,7 +50,10 @@ export async function GET(request: NextRequest) {
         // Default ON: missing or any value other than 'false' is treated as enabled.
         const skipUnreleased = value !== 'false';
 
-        return NextResponse.json({ skipUnreleased });
+        const minQualityScore = parseMinQualityScore(await configService.get(MIN_SCORE_KEY));
+        const minQualityScoreEbook = parseMinQualityScore(await configService.get(MIN_SCORE_EBOOK_KEY));
+
+        return NextResponse.json({ skipUnreleased, minQualityScore, minQualityScoreEbook });
       } catch (error) {
         logger.error('Failed to fetch indexer options', {
           error: error instanceof Error ? error.message : String(error),
@@ -55,15 +68,28 @@ export async function GET(request: NextRequest) {
 }
 
 /**
+ * Validate an optional minimum-score field: when present it must be an integer 0-100.
+ * Returns an error message string if invalid, otherwise null.
+ */
+function validateScore(value: unknown, field: string): string | null {
+  if (value === undefined) return null;
+  if (typeof value !== 'number' || !Number.isInteger(value) || value < 0 || value > 100) {
+    return `${field} must be an integer between 0 and 100`;
+  }
+  return null;
+}
+
+/**
  * PUT /api/admin/settings/indexer-options
- * Persists indexer-wide options. Body: { skipUnreleased: boolean }
+ * Persists indexer-wide options.
+ * Body: { skipUnreleased: boolean, minQualityScore?: number, minQualityScoreEbook?: number }
  */
 export async function PUT(request: NextRequest) {
   return requireAuth(request, async (req: AuthenticatedRequest) => {
     return requireAdmin(req, async () => {
       try {
         const body = await request.json();
-        const { skipUnreleased } = body ?? {};
+        const { skipUnreleased, minQualityScore, minQualityScoreEbook } = body ?? {};
 
         if (typeof skipUnreleased !== 'boolean') {
           return NextResponse.json(
@@ -72,8 +98,15 @@ export async function PUT(request: NextRequest) {
           );
         }
 
+        const scoreError =
+          validateScore(minQualityScore, 'minQualityScore') ??
+          validateScore(minQualityScoreEbook, 'minQualityScoreEbook');
+        if (scoreError) {
+          return NextResponse.json({ error: scoreError }, { status: 400 });
+        }
+
         const configService = getConfigService();
-        await configService.setMany([
+        const updates = [
           {
             key: CONFIG_KEY,
             value: String(skipUnreleased),
@@ -81,14 +114,41 @@ export async function PUT(request: NextRequest) {
             description:
               'Skip auto-searches for books with future release dates',
           },
-        ]);
+        ];
 
-        // Explicitly clear cache for the key after write. `setMany` already
+        if (minQualityScore !== undefined) {
+          updates.push({
+            key: MIN_SCORE_KEY,
+            value: String(minQualityScore),
+            category: 'indexer',
+            description:
+              'Minimum ranking score (0-100) for automatic audiobook searches',
+          });
+        }
+        if (minQualityScoreEbook !== undefined) {
+          updates.push({
+            key: MIN_SCORE_EBOOK_KEY,
+            value: String(minQualityScoreEbook),
+            category: 'indexer',
+            description:
+              'Minimum ranking score (0-100) for automatic e-book searches',
+          });
+        }
+
+        await configService.setMany(updates);
+
+        // Explicitly clear cache for the keys after write. `setMany` already
         // does this, but we make it visible here to guarantee fresh reads
-        // by any sibling service that has cached the value.
+        // by any sibling service that has cached the values.
         configService.clearCache(CONFIG_KEY);
+        configService.clearCache(MIN_SCORE_KEY);
+        configService.clearCache(MIN_SCORE_EBOOK_KEY);
 
-        logger.info('Indexer options updated', { skipUnreleased });
+        logger.info('Indexer options updated', {
+          skipUnreleased,
+          minQualityScore,
+          minQualityScoreEbook,
+        });
 
         return NextResponse.json({
           success: true,

--- a/src/app/api/admin/settings/route.ts
+++ b/src/app/api/admin/settings/route.ts
@@ -7,6 +7,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { requireAuth, requireAdmin, AuthenticatedRequest } from '@/lib/middleware/auth';
 import { prisma } from '@/lib/db';
 import { RMABLogger } from '@/lib/utils/logger';
+import { parseMinQualityScore } from '@/lib/utils/min-quality-score';
 
 const logger = RMABLogger.create('API.Admin.Settings');
 
@@ -86,6 +87,11 @@ export async function GET(request: NextRequest) {
         // Must stay in lock-step with /api/admin/settings/indexer-options read contract
         // and any background worker that reads `indexer.skip_unreleased` directly.
         skipUnreleased: configMap.get('indexer.skip_unreleased') !== 'false',
+        // Minimum ranking score thresholds for automatic searches. Default 50,
+        // clamped 0-100. Must stay in lock-step with the indexer-options route
+        // and the search processors that read these keys directly.
+        minQualityScore: parseMinQualityScore(configMap.get('indexer.min_quality_score')),
+        minQualityScoreEbook: parseMinQualityScore(configMap.get('indexer.min_quality_score_ebook')),
       },
       // downloadClient is populated from multi-client format for backward compatibility
       // The DownloadTab component now uses DownloadClientManagement which reads from /api/admin/settings/download-clients

--- a/src/components/admin/MinScoreSlider.tsx
+++ b/src/components/admin/MinScoreSlider.tsx
@@ -1,0 +1,104 @@
+/**
+ * Component: Minimum Score Threshold Slider
+ * Documentation: documentation/settings-pages.md
+ *
+ * Optional control for the ranking algorithm's minimum-score threshold used by
+ * automatic searches. Range 0-100, default 50. Higher = stricter (may find
+ * nothing), lower = more lenient (grabs weaker releases). A value of 0 still
+ * relies on the independent title/author match gate to reject wrong books.
+ */
+
+'use client';
+
+import React from 'react';
+
+interface MinScoreSliderProps {
+  /** Display label for this threshold (e.g. "Audiobooks"). */
+  label: string;
+  /** Natural-language media noun used in help text (e.g. "audiobook"). */
+  mediaLabel: string;
+  /** Current threshold value (0-100). */
+  value: number;
+  /** Called with the new value when the slider moves. */
+  onChange: (value: number) => void;
+}
+
+export function MinScoreSlider({ label, mediaLabel, value, onChange }: MinScoreSliderProps) {
+  // Color the numeric readout by zone: lenient (low), balanced (mid), strict (high).
+  const getValueColor = (v: number): string => {
+    if (v === 0) return 'text-red-700 dark:text-red-400';
+    if (v < 35) return 'text-yellow-600 dark:text-yellow-500';
+    if (v > 75) return 'text-orange-600 dark:text-orange-400';
+    return 'text-green-600 dark:text-green-500';
+  };
+
+  // Fill the track up to the current position (blue fill = configured strictness).
+  const getSliderBackground = (v: number): string => {
+    return `linear-gradient(to right,
+      #3b82f6 0%,
+      #3b82f6 ${v}%,
+      #e5e7eb ${v}%,
+      #e5e7eb 100%)`;
+  };
+
+  return (
+    <div className="border border-gray-200 dark:border-gray-700 rounded-lg p-4 bg-gray-50 dark:bg-gray-800">
+      <div className="flex items-center justify-between mb-2">
+        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+          {label}
+        </label>
+        <span className={`text-sm font-bold min-w-[48px] text-right ${getValueColor(value)}`}>
+          {value}/100
+        </span>
+      </div>
+
+      <div className="flex items-center gap-3 mb-3">
+        <span className="text-xs text-gray-500 dark:text-gray-400 w-8 text-right">0</span>
+        <div className="flex-1 relative">
+          <input
+            type="range"
+            min="0"
+            max="100"
+            step="1"
+            value={value}
+            onChange={(e) => onChange(parseInt(e.target.value, 10))}
+            className="w-full h-2 rounded-lg appearance-none cursor-pointer min-score-slider"
+            style={{ background: getSliderBackground(value) }}
+          />
+          <style jsx>{`
+            .min-score-slider::-webkit-slider-thumb {
+              appearance: none;
+              width: 18px;
+              height: 18px;
+              border-radius: 50%;
+              background: white;
+              border: 2px solid #3b82f6;
+              cursor: pointer;
+              box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+            }
+            .min-score-slider::-moz-range-thumb {
+              width: 18px;
+              height: 18px;
+              border-radius: 50%;
+              background: white;
+              border: 2px solid #3b82f6;
+              cursor: pointer;
+              box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+            }
+          `}</style>
+        </div>
+        <span className="text-xs text-gray-500 dark:text-gray-400 w-8">100</span>
+      </div>
+
+      {value === 0 && (
+        <div className="mt-3 p-3 rounded-lg text-xs bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 text-red-800 dark:text-red-200">
+          ⚠️ <span className="font-medium">Threshold disabled.</span> At 0, automatic
+          searches accept the highest-ranked {mediaLabel} that matches the title and
+          author, no matter how poor its quality (seeders, size, format). Wrong books
+          are still rejected by the match check, but you may download low-quality
+          releases. Raise this if you want a quality floor.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/processors/search-ebook.processor.ts
+++ b/src/lib/processors/search-ebook.processor.ts
@@ -16,6 +16,7 @@ import { rankEbookTorrents, RankedEbookTorrent } from '../utils/ranking-algorith
 import { groupIndexersByCategories, getGroupDescription } from '../utils/indexer-grouping';
 import { getLanguageForRegion } from '../constants/language-config';
 import { filterBlockedResults } from '../utils/filter-blocked-results';
+import { parseMinQualityScore } from '../utils/min-quality-score';
 import type { AudibleRegion } from '../types/audible';
 
 // Import ebook scraper functions for Anna's Archive
@@ -24,6 +25,12 @@ import {
   searchByTitle,
   getSlowDownloadLinks,
 } from '../services/ebook-scraper';
+
+/**
+ * Title/author match gate: a correctly-identified book has matchScore > 0.
+ * Applied independently of minQualityScore so a value of 0 still rejects wrong books.
+ */
+const EBOOK_MIN_MATCH_SCORE = 1;
 
 /**
  * Process search ebook job
@@ -259,6 +266,9 @@ async function searchIndexers(
   const flagConfigStr = await configService.get('indexer_flag_config');
   const flagConfigs = flagConfigStr ? JSON.parse(flagConfigStr) : [];
 
+  // Admin-configurable minimum ranking score for automatic ebook searches (default 50)
+  const minQualityScore = parseMinQualityScore(await configService.get('indexer.min_quality_score_ebook'));
+
   // Group indexers by their EBOOK category configuration
   const { groups, skippedIndexers } = groupIndexersByCategories(indexersConfig, 'ebook');
 
@@ -353,16 +363,20 @@ async function searchIndexers(
     logger.info(`Filtered out ${preFilterCount - postFilterCount} results > 20 MB`);
   }
 
-  // Dual threshold filtering (same as audiobooks)
+  // Dual threshold filtering (same as audiobooks):
+  // base + final must clear minQualityScore, and the title/author match gate
+  // (matchScore > 0) must pass so a value of 0 still rejects wrong books.
   const filteredResults = rankedResults.filter(result =>
-    result.score >= 50 && result.finalScore >= 50
+    result.score >= minQualityScore &&
+    result.finalScore >= minQualityScore &&
+    result.breakdown.matchScore >= EBOOK_MIN_MATCH_SCORE
   );
 
   const disqualifiedByNegativeBonus = rankedResults.filter(result =>
-    result.score >= 50 && result.finalScore < 50
+    result.score >= minQualityScore && result.finalScore < minQualityScore
   ).length;
 
-  logger.info(`Ranked ${rankedResults.length} results, ${filteredResults.length} above threshold (50/100 base + final)`);
+  logger.info(`Ranked ${rankedResults.length} results, ${filteredResults.length} above threshold (${minQualityScore}/100 base + final, match>0)`);
   if (disqualifiedByNegativeBonus > 0) {
     logger.info(`${disqualifiedByNegativeBonus} ebooks disqualified by negative flag bonuses`);
   }

--- a/src/lib/processors/search-indexers.processor.ts
+++ b/src/lib/processors/search-indexers.processor.ts
@@ -11,16 +11,8 @@ import { groupIndexersByCategories, getGroupDescription } from '../utils/indexer
 import { RMABLogger } from '../utils/logger';
 import { getLanguageForRegion } from '../constants/language-config';
 import { filterBlockedResults } from '../utils/filter-blocked-results';
+import { parseMinQualityScore } from '../utils/min-quality-score';
 import type { AudibleRegion } from '../types/audible';
-
-/**
- * Minimum acceptable quality score (0-100, base + final).
- * Lowered from 50 → 40: on a single high-quality indexer (e.g. MAM) genuinely
- * low-quality torrents are rare, so the old bar mostly rejected correct books
- * with modest size/seeder scores. Wrong books are still excluded because they
- * earn matchScore=0 (failed title/author gate) — see MIN_MATCH_SCORE.
- */
-const MIN_QUALITY_SCORE = 40;
 
 /**
  * A correctly-identified book must clear the title/author match gate.
@@ -82,6 +74,9 @@ export async function processSearchIndexers(payload: SearchIndexersPayload): Pro
     // Get flag configurations
     const flagConfigStr = await configService.get('indexer_flag_config');
     const flagConfigs = flagConfigStr ? JSON.parse(flagConfigStr) : [];
+
+    // Admin-configurable minimum ranking score for automatic searches (default 50)
+    const minQualityScore = parseMinQualityScore(await configService.get('indexer.min_quality_score'));
 
     // Group indexers by their category configuration
     // This minimizes API calls while ensuring each indexer only searches its configured categories
@@ -216,28 +211,28 @@ export async function processSearchIndexers(payload: SearchIndexersPayload): Pro
     }
 
     // Dual threshold filtering:
-    // 1. Base score must be >= MIN_QUALITY_SCORE (quality minimum)
-    // 2. Final score must be >= MIN_QUALITY_SCORE (not disqualified by negative bonuses)
+    // 1. Base score must be >= minQualityScore (quality minimum)
+    // 2. Final score must be >= minQualityScore (not disqualified by negative bonuses)
     // 3. Title/author match gate must have passed (matchScore > 0) so the
-    //    relaxed quality bar can't admit a wrong book.
+    //    quality bar can't admit a wrong book — applies even when minQualityScore is 0.
     const filteredResults = rankedResults.filter(result =>
-      result.score >= MIN_QUALITY_SCORE &&
-      result.finalScore >= MIN_QUALITY_SCORE &&
+      result.score >= minQualityScore &&
+      result.finalScore >= minQualityScore &&
       result.breakdown.matchScore >= MIN_MATCH_SCORE
     );
 
     const disqualifiedByNegativeBonus = rankedResults.filter(result =>
-      result.score >= MIN_QUALITY_SCORE && result.finalScore < MIN_QUALITY_SCORE
+      result.score >= minQualityScore && result.finalScore < minQualityScore
     ).length;
 
-    logger.info(`Ranked ${rankedResults.length} results, ${filteredResults.length} above threshold (${MIN_QUALITY_SCORE}/100 base + final, match>0)`);
+    logger.info(`Ranked ${rankedResults.length} results, ${filteredResults.length} above threshold (${minQualityScore}/100 base + final, match>0)`);
     if (disqualifiedByNegativeBonus > 0) {
       logger.info(`${disqualifiedByNegativeBonus} torrents disqualified by negative flag bonuses`);
     }
 
     if (filteredResults.length === 0) {
       // No quality results found - queue for re-search instead of failing
-      logger.warn(`No quality matches found for request ${requestId} (all below ${MIN_QUALITY_SCORE}/100 or failed title/author match), marking as awaiting_search`);
+      logger.warn(`No quality matches found for request ${requestId} (all below ${minQualityScore}/100 or failed title/author match), marking as awaiting_search`);
 
       await prisma.request.update({
         where: { id: requestId },

--- a/src/lib/processors/search-indexers.processor.ts
+++ b/src/lib/processors/search-indexers.processor.ts
@@ -14,6 +14,23 @@ import { filterBlockedResults } from '../utils/filter-blocked-results';
 import type { AudibleRegion } from '../types/audible';
 
 /**
+ * Minimum acceptable quality score (0-100, base + final).
+ * Lowered from 50 → 40: on a single high-quality indexer (e.g. MAM) genuinely
+ * low-quality torrents are rare, so the old bar mostly rejected correct books
+ * with modest size/seeder scores. Wrong books are still excluded because they
+ * earn matchScore=0 (failed title/author gate) — see MIN_MATCH_SCORE.
+ */
+const MIN_QUALITY_SCORE = 40;
+
+/**
+ * A correctly-identified book must clear the title/author match gate.
+ * matchScore is 0 when the author is absent or <80% of required title words
+ * are present, so requiring >0 keeps wrong-book torrents out even though the
+ * overall quality bar is relaxed.
+ */
+const MIN_MATCH_SCORE = 1;
+
+/**
  * Process search indexers job
  * Searches configured indexers for audiobook torrents
  */
@@ -199,24 +216,28 @@ export async function processSearchIndexers(payload: SearchIndexersPayload): Pro
     }
 
     // Dual threshold filtering:
-    // 1. Base score must be >= 50 (quality minimum)
-    // 2. Final score must be >= 50 (not disqualified by negative bonuses)
+    // 1. Base score must be >= MIN_QUALITY_SCORE (quality minimum)
+    // 2. Final score must be >= MIN_QUALITY_SCORE (not disqualified by negative bonuses)
+    // 3. Title/author match gate must have passed (matchScore > 0) so the
+    //    relaxed quality bar can't admit a wrong book.
     const filteredResults = rankedResults.filter(result =>
-      result.score >= 50 && result.finalScore >= 50
+      result.score >= MIN_QUALITY_SCORE &&
+      result.finalScore >= MIN_QUALITY_SCORE &&
+      result.breakdown.matchScore >= MIN_MATCH_SCORE
     );
 
     const disqualifiedByNegativeBonus = rankedResults.filter(result =>
-      result.score >= 50 && result.finalScore < 50
+      result.score >= MIN_QUALITY_SCORE && result.finalScore < MIN_QUALITY_SCORE
     ).length;
 
-    logger.info(`Ranked ${rankedResults.length} results, ${filteredResults.length} above threshold (50/100 base + final)`);
+    logger.info(`Ranked ${rankedResults.length} results, ${filteredResults.length} above threshold (${MIN_QUALITY_SCORE}/100 base + final, match>0)`);
     if (disqualifiedByNegativeBonus > 0) {
       logger.info(`${disqualifiedByNegativeBonus} torrents disqualified by negative flag bonuses`);
     }
 
     if (filteredResults.length === 0) {
       // No quality results found - queue for re-search instead of failing
-      logger.warn(`No quality matches found for request ${requestId} (all below 50/100), marking as awaiting_search`);
+      logger.warn(`No quality matches found for request ${requestId} (all below ${MIN_QUALITY_SCORE}/100 or failed title/author match), marking as awaiting_search`);
 
       await prisma.request.update({
         where: { id: requestId },

--- a/src/lib/utils/min-quality-score.ts
+++ b/src/lib/utils/min-quality-score.ts
@@ -1,0 +1,22 @@
+/**
+ * Component: Minimum Quality Score helpers
+ * Documentation: documentation/settings-pages.md
+ *
+ * Single source of truth for the automatic-search minimum ranking threshold.
+ * The settings GET route, the indexer-options route, and the search processors
+ * all read the same `indexer.min_quality_score(_ebook)` config keys and MUST
+ * interpret them identically — share this helper rather than re-deriving it.
+ */
+
+/** Default threshold used when the admin has not configured one. */
+export const DEFAULT_MIN_QUALITY_SCORE = 50;
+
+/**
+ * Parse a stored minimum-score threshold into a clamped integer 0-100.
+ * Missing/invalid values fall back to DEFAULT_MIN_QUALITY_SCORE.
+ */
+export function parseMinQualityScore(value: string | null | undefined): number {
+  const parsed = parseInt(value ?? '', 10);
+  if (Number.isNaN(parsed)) return DEFAULT_MIN_QUALITY_SCORE;
+  return Math.min(100, Math.max(0, parsed));
+}

--- a/src/lib/utils/ranking-algorithm.ts
+++ b/src/lib/utils/ranking-algorithm.ts
@@ -609,9 +609,12 @@ export class RankingAlgorithm {
     }
 
     // ========== STAGE 3: AUTHOR MATCHING (0-15 points) ==========
-    // Check how many authors appear in torrent title (exact substring match)
+    // Check how many authors appear in torrent title (exact substring match).
+    // Also try the initials-collapsed form so "TJ Klune" matches "T J Klune".
+    const collapsedTorrentTitle = this.collapseInitials(torrentTitle);
     const authorMatches = normalizedAuthors.filter(author =>
-      torrentTitle.includes(author)
+      torrentTitle.includes(author) ||
+      collapsedTorrentTitle.includes(this.collapseInitials(author))
     );
 
     let authorScore = 0;
@@ -627,6 +630,28 @@ export class RankingAlgorithm {
   }
 
   /**
+   * Collapse runs of single-letter tokens into one token so spaced and
+   * compacted initials compare equal.
+   *   "t j klune"        → "tj klune"
+   *   "george r r martin"→ "george rr martin"
+   * Input must already be normalized (lowercased, punctuation→spaces).
+   */
+  private collapseInitials(text: string): string {
+    const out: string[] = [];
+    let buf = '';
+    for (const word of text.split(/\s+/)) {
+      if (word.length === 1) {
+        buf += word; // accumulate consecutive single letters
+      } else {
+        if (buf) { out.push(buf); buf = ''; }
+        if (word) out.push(word);
+      }
+    }
+    if (buf) out.push(buf);
+    return out.join(' ');
+  }
+
+  /**
    * Check if author is present in torrent title with high confidence
    * Uses pre-parsed and normalized authors array
    *
@@ -635,17 +660,26 @@ export class RankingAlgorithm {
    * @returns true if at least ONE author is present with high confidence
    */
   private checkAuthorPresenceWithParsed(torrentTitle: string, normalizedAuthors: string[]): boolean {
+    // Collapsed-initials variant of the title so "T J Klune" matches "TJ Klune"
+    const collapsedTitle = this.collapseInitials(torrentTitle);
+
     // At least ONE author must match with high confidence
     return normalizedAuthors.some(author => {
-      // Check 1: Exact substring match (works well now that both are normalized)
-      if (torrentTitle.includes(author)) {
+      const collapsedAuthor = this.collapseInitials(author);
+
+      // Check 1: Exact substring match (raw OR initials-collapsed form)
+      // Handles: "TJ Klune" vs "T J Klune", "JD Robb" vs "J D Robb"
+      if (torrentTitle.includes(author) || collapsedTitle.includes(collapsedAuthor)) {
         return true;
       }
 
       // Check 2: High fuzzy similarity (≥ 0.85)
       // Handles: "J.K. Rowling" vs "J. K. Rowling" vs "JK Rowling"
       // Also handles: "Dennis E. Taylor" vs "Dennis Taylor"
-      const similarity = compareTwoStrings(author, torrentTitle);
+      const similarity = Math.max(
+        compareTwoStrings(author, torrentTitle),
+        compareTwoStrings(collapsedAuthor, collapsedTitle)
+      );
       if (similarity >= 0.85) {
         return true;
       }
@@ -654,13 +688,14 @@ export class RankingAlgorithm {
       // Handles: "Sanderson, Brandon" vs "Brandon Sanderson"
       // Handles: "Brandon R. Sanderson" vs "Brandon Sanderson"
       // Now also handles: "VirginaEvans" → "virgina evans" (after normalization)
-      const words = author.split(/\s+/).filter(w => w.length > 1);
+      // Use the collapsed forms so initials-based names resolve correctly.
+      const words = collapsedAuthor.split(/\s+/).filter(w => w.length > 1);
       if (words.length >= 2) {
         const firstName = words[0];
         const lastName = words[words.length - 1];
 
-        const firstIdx = torrentTitle.indexOf(firstName);
-        const lastIdx = torrentTitle.indexOf(lastName);
+        const firstIdx = collapsedTitle.indexOf(firstName);
+        const lastIdx = collapsedTitle.indexOf(lastName);
 
         // Both components present and reasonably close?
         if (firstIdx !== -1 && lastIdx !== -1) {

--- a/tests/utils/ranking-algorithm.test.ts
+++ b/tests/utils/ranking-algorithm.test.ts
@@ -1398,6 +1398,87 @@ describe('ranking-algorithm', () => {
       expect(ranked[0].bonusModifiers.length).toBeGreaterThan(0);
     });
   });
+
+  describe('Author Initials Normalization', () => {
+    const algorithm = new RankingAlgorithm();
+
+    it('matches compacted author initials against spaced initials (TJ Klune ≡ T J Klune)', () => {
+      const torrent = {
+        ...baseTorrent,
+        title: 'Olive Juice by T J Klune [ENG / M4B]',
+      };
+
+      const breakdown = algorithm.getScoreBreakdown(torrent, {
+        title: 'Olive Juice',
+        author: 'TJ Klune',
+      });
+
+      // Author gate must pass and full title match must score
+      expect(breakdown.matchScore).toBeGreaterThan(50);
+    });
+
+    it('matches spaced initials against compacted (J D Robb ≡ JD Robb)', () => {
+      const torrent = {
+        ...baseTorrent,
+        title: 'Naked in Death by JD Robb',
+      };
+
+      const breakdown = algorithm.getScoreBreakdown(torrent, {
+        title: 'Naked in Death',
+        author: 'J D Robb',
+      });
+
+      expect(breakdown.matchScore).toBeGreaterThan(50);
+    });
+
+    it('matches three-part initials (George R R Martin ≡ George RR Martin)', () => {
+      const torrent = {
+        ...baseTorrent,
+        title: 'A Game of Thrones by George RR Martin',
+      };
+
+      const breakdown = algorithm.getScoreBreakdown(torrent, {
+        title: 'A Game of Thrones',
+        author: 'George R R Martin',
+      });
+
+      expect(breakdown.matchScore).toBeGreaterThan(50);
+    });
+
+    it('still rejects a wrong author even with initials normalization', () => {
+      const torrent = {
+        ...baseTorrent,
+        title: 'Some Other Book by Jane Doe',
+      };
+
+      const breakdown = algorithm.getScoreBreakdown(torrent, {
+        title: 'Olive Juice',
+        author: 'TJ Klune',
+      });
+
+      // Author gate fails → entire match block zeroed
+      expect(breakdown.matchScore).toBe(0);
+    });
+
+    it('selects the real Olive Juice torrent end-to-end (regression)', () => {
+      // Real MAM result: 141 MB M4B, 36 seeders, runtime 311 min
+      const torrent = {
+        ...baseTorrent,
+        title: 'Olive Juice by T J Klune [ENG / M4B]',
+        size: 148268640,
+        seeders: 36,
+      };
+
+      const ranked = rankTorrents(
+        [torrent],
+        { title: 'Olive Juice', author: 'TJ Klune', durationMinutes: 311 }
+      );
+
+      expect(ranked).toHaveLength(1);
+      // Base score comfortably clears the lowered 40/100 bar
+      expect(ranked[0].score).toBeGreaterThan(40);
+    });
+  });
 });
 
 


### PR DESCRIPTION
# Fix torrent ranking for authors with initials; make the minimum-score threshold configurable

## Problem
1. The ranking algorithm's author-presence gate could not reconcile compacted
   initials ("JRR Tolkien") with spaced initials ("J R R Tolkien"). Because that gate
   hard-zeros the entire 60-point title/author match when the author isn't found,
   correct, well-seeded releases were scored far below the accept threshold and
   rejected — leaving requests stuck in `awaiting_search`. It affected any
   initials-style author (JD Robb / J D Robb, George RR Martin / George R R Martin,
   W E B Griffin, etc.).
2. The automatic-search accept threshold was hard-coded, so the only way to make
   it stricter or more lenient was a code change. Different setups need different
   bars (a single high-quality indexer vs. many noisy public ones).
   
   
<img width="1032" height="488" alt="image" src="https://github.com/user-attachments/assets/2c2b2117-ae5c-42eb-acfd-dc5a8a9c0688" />


## Fix
- Add an initials-normalization step (`collapseInitials`) that joins runs of
  single-letter tokens, applied in `checkAuthorPresenceWithParsed` and the
  Stage-3 author substring scoring so spaced and compacted initials compare
  equal.
- Make the accept threshold **admin-configurable** instead of a hard-coded number.
  Two optional sliders on **Settings → Indexers** (styled like the Indexer Flag
  Configuration section, marked Optional):
  - **Audiobooks** → config key `indexer.min_quality_score`
  - **E-books** → config key `indexer.min_quality_score_ebook`

  Each ranges **0–100, default 50**, with inline help explaining the trade-offs
  (too high rejects everything and stalls requests in `awaiting_search`; too low
  grabs weaker matches) and a warning when set to **0**. The title/author match
  gate (`matchScore > 0`) still applies independently, so even at 0 a wrong
  title/author is rejected. Manual/interactive searches remain unfiltered.
  The search processors read these keys at runtime (clamped 0–100; missing/invalid
  → 50).
- For e-books, the same change also adds the title/author match gate
  (`matchScore > 0`) the audiobook path already had, so a wrong-author release can
  no longer slip through on size/seeder/format score alone.
- The clamp/default logic is centralized in one helper
  (`parseMinQualityScore` / `DEFAULT_MIN_QUALITY_SCORE`) shared by all four read
  sites, since the settings GET, the indexer-options route, and both processors
  must interpret the keys identically.

## Tests
- Regression coverage for ranking: the initials variants and a
  wrong-author negative to confirm the gate still rejects mismatches.
- Processor + settings coverage: `search-indexers` / `search-ebook` honor the
  configured threshold (default 50) and the match gate; `indexer-options` persists
  and validates the new keys (integer 0–100); settings save sends them.

## Scope
- `src/lib/utils/ranking-algorithm.ts` — initials normalization
- `src/lib/processors/search-indexers.processor.ts`,
  `src/lib/processors/search-ebook.processor.ts` — read configurable threshold
- `src/lib/utils/min-quality-score.ts` — shared parse/clamp helper + default
- `src/components/admin/MinScoreSlider.tsx` — new slider component
- `src/app/admin/settings/tabs/IndexersTab/IndexersTab.tsx`,
  `src/app/admin/settings/lib/{types,helpers}.ts` — UI + wiring
- `src/app/api/admin/settings/route.ts`,
  `src/app/api/admin/settings/indexer-options/route.ts` — load/save/validate
- Docs: `documentation/settings-pages.md`, `documentation/phase3/ranking-algorithm.md`,
  `documentation/TABLEOFCONTENTS.md`
- Ranking test file + processor/helpers tests
