### PR TITLE
fix: rotate Retry Missing Torrents search so it doesn't re-search the same 50

### DIFF
--- a/src/lib/processors/retry-missing-torrents.processor.ts
+++ b/src/lib/processors/retry-missing-torrents.processor.ts
@@ -39,8 +39,10 @@ export async function processRetryMissingTorrents(payload: RetryMissingTorrentsP
       include: {
         audiobook: true,
       },
+      orderBy: { lastSearchAt: { sort: 'asc', nulls: 'first' } },
       take: 50,
     });
+    
 
     logger.info(`Found ${requests.length} requests awaiting search/release`);
 


### PR DESCRIPTION
## Problem

`retry_missing_torrents` fetches requests to re-search with no ordering:

    const requests = await prisma.request.findMany({
      where: { status: { in: ['awaiting_search', 'awaiting_release'] }, deletedAt: null },
      include: { audiobook: true },
      take: 50,
    });

With no `orderBy`, Postgres returns the same 50 rows every run. Findable titles
download and leave the pool, but un-findable ones (0 results on the configured
indexers) stay at the front and get re-searched forever. Once those 50 slots fill
with un-findable books, the job loops on them and never reaches the rest of the
backlog.

## Fix

Order by `lastSearchAt` ascending, nulls first:

    orderBy: { lastSearchAt: { sort: 'asc', nulls: 'first' } },

Never-searched requests go first; otherwise least-recently-searched. Each empty
search already stamps `lastSearchAt` (search-indexers.processor.ts), so re-tried
books drop to the back and the next batch gets a turn. `nulls: 'first'` matters
because Postgres puts NULLs last by default, which would deprioritise
never-searched requests.

No migration needed (`lastSearchAt` already exists on the Request model). No API
or frontend change.