### PR TITLE
feat: add watched author catalog mode

### DIFF
--- a/documentation/TABLEOFCONTENTS.md
+++ b/documentation/TABLEOFCONTENTS.md
@@ -42,6 +42,9 @@
 - **Hook factory (createShelfHooks)** → [backend/services/goodreads-sync.md](backend/services/goodreads-sync.md#hook-factory)
 - **Adding a new shelf provider** → [backend/services/goodreads-sync.md](backend/services/goodreads-sync.md#adding-a-new-provider)
 
+## Watched Lists
+- **Watch series/authors, author catalog mode** → [features/watched-lists.md](features/watched-lists.md)
+
 ## Audible Integration
 - **Web scraping (popular, new releases)** → [integrations/audible.md](integrations/audible.md)
 - **Database caching, real-time matching** → [integrations/audible.md](integrations/audible.md)

--- a/documentation/features/watched-lists.md
+++ b/documentation/features/watched-lists.md
@@ -1,0 +1,31 @@
+# Watched Series and Authors
+
+**Status:** ✅ Implemented | Automatic requests for followed series/authors
+
+## Overview
+Watched lists periodically check Audible and request books the user does not already own.
+
+## Key Details
+- **Series:** Requests existing missing books and future additions.
+- **Authors:** Per-user mode:
+  - `includeBackCatalog=false` (default): release date must be on/after the follow date.
+  - `includeBackCatalog=true`: all discovered books are eligible.
+- Existing watched authors keep entire-catalog behavior when this setting is introduced.
+- Author mode can be changed from the profile page.
+- Switching an author to entire-catalog mode triggers an immediate check.
+- Books without a valid release date are skipped in new-release mode.
+- Duplicate/owned books are skipped by the existing request and works-table checks.
+
+## API
+- `GET /api/user/watched-authors` → includes `includeBackCatalog`.
+- `POST /api/user/watched-authors` → accepts optional `includeBackCatalog` (default `false`).
+- `PATCH /api/user/watched-authors/:id` → `{ includeBackCatalog: boolean }`.
+- `DELETE /api/user/watched-authors/:id` → removes the subscription.
+
+## Data Model
+- `WatchedAuthor.includeBackCatalog Boolean @default(false)` → `include_back_catalog`.
+
+## Related
+- `src/lib/services/watched-lists.service.ts`
+- `src/components/ui/WatchButton.tsx`
+- `src/components/profile/WatchedListsSection.tsx`

--- a/prisma/migrations/20260813000000_add_watched_author_catalog_mode/migration.sql
+++ b/prisma/migrations/20260813000000_add_watched_author_catalog_mode/migration.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "watched_authors"
+ADD COLUMN "include_back_catalog" BOOLEAN NOT NULL DEFAULT false;
+
+UPDATE "watched_authors"
+SET "include_back_catalog" = true;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -708,6 +708,7 @@ model WatchedAuthor {
   authorAsin    String    @map("author_asin")
   authorName    String    @map("author_name")
   coverArtUrl   String?   @map("cover_art_url") @db.Text
+  includeBackCatalog Boolean @default(false) @map("include_back_catalog")
   lastCheckedAt DateTime? @map("last_checked_at")
   createdAt     DateTime  @default(now()) @map("created_at")
   updatedAt     DateTime  @updatedAt @map("updated_at")

--- a/src/app/api/user/watched-authors/[id]/route.ts
+++ b/src/app/api/user/watched-authors/[id]/route.ts
@@ -1,5 +1,5 @@
 /**
- * Component: Watched Author Delete Route
+ * Component: Watched Author Item Route
  * Documentation: documentation/features/watched-lists.md
  */
 
@@ -7,8 +7,56 @@ import { NextRequest, NextResponse } from 'next/server';
 import { requireAuth, AuthenticatedRequest } from '@/lib/middleware/auth';
 import { prisma } from '@/lib/db';
 import { RMABLogger } from '@/lib/utils/logger';
+import { getJobQueueService } from '@/lib/services/job-queue.service';
+import { z } from 'zod';
 
 const logger = RMABLogger.create('API.WatchedAuthors');
+const UpdateWatchedAuthorSchema = z.object({ includeBackCatalog: z.boolean() });
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  return requireAuth(request, async (req: AuthenticatedRequest) => {
+    try {
+      if (!req.user) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+      }
+
+      const { id } = await params;
+      const { includeBackCatalog } = UpdateWatchedAuthorSchema.parse(await req.json());
+      const watched = await prisma.watchedAuthor.findUnique({ where: { id } });
+
+      if (!watched) {
+        return NextResponse.json({ error: 'Watched author not found' }, { status: 404 });
+      }
+      if (watched.userId !== req.user.id) {
+        return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+      }
+
+      const updated = await prisma.watchedAuthor.update({
+        where: { id },
+        data: { includeBackCatalog },
+      });
+
+      if (includeBackCatalog && !watched.includeBackCatalog) {
+        try {
+          await getJobQueueService().addCheckWatchedItemJob(req.user.id, undefined, watched.authorAsin);
+        } catch (error) {
+          logger.error('Failed to trigger watched author check', { error: error instanceof Error ? error.message : String(error) });
+        }
+      }
+
+      return NextResponse.json({ success: true, author: updated });
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        return NextResponse.json({ error: 'ValidationError', details: error.errors }, { status: 400 });
+      }
+      logger.error('Failed to update watched author', { error: error instanceof Error ? error.message : String(error) });
+      return NextResponse.json({ error: 'Failed to update watched author' }, { status: 500 });
+    }
+  });
+}
 
 /**
  * DELETE /api/user/watched-authors/[id]

--- a/src/app/api/user/watched-authors/route.ts
+++ b/src/app/api/user/watched-authors/route.ts
@@ -16,6 +16,7 @@ const AddWatchedAuthorSchema = z.object({
   authorAsin: z.string().regex(/^[A-Z0-9]{10}$/, 'Invalid author ASIN'),
   authorName: z.string().min(1).max(500),
   coverArtUrl: z.string().url().optional(),
+  includeBackCatalog: z.boolean().default(false),
 });
 
 /**
@@ -41,6 +42,7 @@ export async function GET(request: NextRequest) {
           authorAsin: a.authorAsin,
           authorName: a.authorName,
           coverArtUrl: a.coverArtUrl,
+          includeBackCatalog: a.includeBackCatalog,
           lastCheckedAt: a.lastCheckedAt,
           createdAt: a.createdAt,
         })),
@@ -64,7 +66,7 @@ export async function POST(request: NextRequest) {
       }
 
       const body = await req.json();
-      const { authorAsin, authorName, coverArtUrl } = AddWatchedAuthorSchema.parse(body);
+      const { authorAsin, authorName, coverArtUrl, includeBackCatalog } = AddWatchedAuthorSchema.parse(body);
 
       // Check for duplicate
       const existing = await prisma.watchedAuthor.findUnique({
@@ -84,6 +86,7 @@ export async function POST(request: NextRequest) {
           authorAsin,
           authorName,
           coverArtUrl: coverArtUrl || null,
+          includeBackCatalog,
         },
       });
 
@@ -105,6 +108,7 @@ export async function POST(request: NextRequest) {
           authorAsin: watched.authorAsin,
           authorName: watched.authorName,
           coverArtUrl: watched.coverArtUrl,
+          includeBackCatalog: watched.includeBackCatalog,
           lastCheckedAt: watched.lastCheckedAt,
           createdAt: watched.createdAt,
         },

--- a/src/components/profile/WatchedListsSection.tsx
+++ b/src/components/profile/WatchedListsSection.tsx
@@ -12,7 +12,7 @@ import React, { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 import { useWatchedSeries, useDeleteWatchedSeries, WatchedSeriesItem } from '@/lib/hooks/useWatchedSeries';
-import { useWatchedAuthors, useDeleteWatchedAuthor, WatchedAuthorItem } from '@/lib/hooks/useWatchedAuthors';
+import { useWatchedAuthors, useDeleteWatchedAuthor, useUpdateWatchedAuthor, WatchedAuthorItem } from '@/lib/hooks/useWatchedAuthors';
 import { usePreferences } from '@/contexts/PreferencesContext';
 
 function formatRelativeTime(dateStr: string | null): string {
@@ -166,12 +166,21 @@ export function WatchedAuthorsSection() {
   const router = useRouter();
   const { authors, isLoading } = useWatchedAuthors();
   const { deleteAuthor, isLoading: isDeleting } = useDeleteWatchedAuthor();
+  const { updateAuthor, isLoading: isUpdating } = useUpdateWatchedAuthor();
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
 
   const handleDelete = async (id: string) => {
     try {
       await deleteAuthor(id);
       setConfirmDeleteId(null);
+    } catch {
+      // Error handled by hook
+    }
+  };
+
+  const handleModeChange = async (id: string, includeBackCatalog: boolean) => {
+    try {
+      await updateAuthor(id, includeBackCatalog);
     } catch {
       // Error handled by hook
     }
@@ -204,6 +213,8 @@ export function WatchedAuthorsSection() {
             onConfirmDelete={() => setConfirmDeleteId(item.id)}
             onCancelDelete={() => setConfirmDeleteId(null)}
             onDelete={() => handleDelete(item.id)}
+            onModeChange={(includeBackCatalog) => handleModeChange(item.id, includeBackCatalog)}
+            isUpdating={isUpdating}
           />
         ))}
       </div>
@@ -212,15 +223,17 @@ export function WatchedAuthorsSection() {
 }
 
 function WatchedAuthorCard({
-  item, isDeleting, confirmingDelete, onNavigate, onConfirmDelete, onCancelDelete, onDelete,
+  item, isDeleting, isUpdating, confirmingDelete, onNavigate, onConfirmDelete, onCancelDelete, onDelete, onModeChange,
 }: {
   item: WatchedAuthorItem;
   isDeleting: boolean;
+  isUpdating: boolean;
   confirmingDelete: boolean;
   onNavigate: () => void;
   onConfirmDelete: () => void;
   onCancelDelete: () => void;
   onDelete: () => void;
+  onModeChange: (includeBackCatalog: boolean) => Promise<unknown>;
 }) {
   return (
     <div className="rounded-xl bg-white dark:bg-gray-800 border border-gray-100 dark:border-gray-700/50 p-4 flex gap-4 hover:shadow-sm transition-shadow">
@@ -250,6 +263,16 @@ function WatchedAuthorCard({
           <p className="text-xs text-gray-400 dark:text-gray-500 mt-0.5">
             Last checked: {formatRelativeTime(item.lastCheckedAt)}
           </p>
+          <select
+            value={item.includeBackCatalog ? 'all' : 'new'}
+            disabled={isUpdating}
+            onChange={(event) => void onModeChange(event.target.value === 'all')}
+            className="mt-2 text-xs bg-transparent text-gray-500 dark:text-gray-400 border border-gray-200 dark:border-gray-600 rounded px-2 py-1"
+            aria-label={`Watch mode for ${item.authorName}`}
+          >
+            <option value="new">New releases only</option>
+            <option value="all">Entire catalog</option>
+          </select>
         </div>
       </div>
 

--- a/src/components/ui/WatchButton.tsx
+++ b/src/components/ui/WatchButton.tsx
@@ -111,6 +111,7 @@ export function WatchAuthorButton({ authorAsin, authorName, coverArtUrl }: Watch
   const { deleteAuthor, isLoading: isDeleting } = useDeleteWatchedAuthor();
   const [error, setError] = useState<string | null>(null);
   const [showConfirm, setShowConfirm] = useState(false);
+  const [includeBackCatalog, setIncludeBackCatalog] = useState(false);
 
   const watchedEntry = authors.find((a) => a.authorAsin === authorAsin);
   const isWatching = !!watchedEntry;
@@ -126,7 +127,7 @@ export function WatchAuthorButton({ authorAsin, authorName, coverArtUrl }: Watch
         setError(err instanceof Error ? err.message : 'Failed');
       }
     } else {
-      // Show confirmation before watching
+      setIncludeBackCatalog(false);
       setShowConfirm(true);
     }
   };
@@ -135,7 +136,7 @@ export function WatchAuthorButton({ authorAsin, authorName, coverArtUrl }: Watch
     setShowConfirm(false);
     setError(null);
     try {
-      await addAuthor(authorAsin, authorName, coverArtUrl);
+      await addAuthor(authorAsin, authorName, coverArtUrl, includeBackCatalog);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed');
     }
@@ -177,7 +178,35 @@ export function WatchAuthorButton({ authorAsin, authorName, coverArtUrl }: Watch
         onClose={() => setShowConfirm(false)}
         onConfirm={handleConfirmWatch}
         title={`Watch "${authorName}"?`}
-        message={`This will request all books by "${authorName}" that aren't already in your library, and automatically request new releases. Continue?`}
+        message={(
+          <div className="space-y-3">
+            <p>Choose which books to request automatically.</p>
+            <label className="flex gap-3 cursor-pointer">
+              <input
+                type="radio"
+                name="author-watch-mode"
+                checked={!includeBackCatalog}
+                onChange={() => setIncludeBackCatalog(false)}
+              />
+              <span>
+                <span className="block font-medium text-gray-900 dark:text-white">New releases only</span>
+                <span className="text-sm">Books released from today forward.</span>
+              </span>
+            </label>
+            <label className="flex gap-3 cursor-pointer">
+              <input
+                type="radio"
+                name="author-watch-mode"
+                checked={includeBackCatalog}
+                onChange={() => setIncludeBackCatalog(true)}
+              />
+              <span>
+                <span className="block font-medium text-gray-900 dark:text-white">Entire catalog</span>
+                <span className="text-sm">Existing books plus future releases.</span>
+              </span>
+            </label>
+          </div>
+        )}
         confirmText="Watch"
         isLoading={isAdding}
       />

--- a/src/lib/hooks/useWatchedAuthors.ts
+++ b/src/lib/hooks/useWatchedAuthors.ts
@@ -15,6 +15,7 @@ export interface WatchedAuthorItem {
   authorAsin: string;
   authorName: string;
   coverArtUrl: string | null;
+  includeBackCatalog: boolean;
   lastCheckedAt: string | null;
   createdAt: string;
 }
@@ -45,7 +46,7 @@ export function useAddWatchedAuthor() {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const addAuthor = async (authorAsin: string, authorName: string, coverArtUrl?: string) => {
+  const addAuthor = async (authorAsin: string, authorName: string, coverArtUrl?: string, includeBackCatalog = false) => {
     if (!accessToken) throw new Error('Not authenticated');
 
     setIsLoading(true);
@@ -55,7 +56,7 @@ export function useAddWatchedAuthor() {
       const response = await fetchWithAuth('/api/user/watched-authors', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ authorAsin, authorName, coverArtUrl }),
+        body: JSON.stringify({ authorAsin, authorName, coverArtUrl, includeBackCatalog }),
       });
 
       const data = await response.json();
@@ -78,6 +79,40 @@ export function useAddWatchedAuthor() {
   };
 
   return { addAuthor, isLoading, error };
+}
+
+export function useUpdateWatchedAuthor() {
+  const { accessToken } = useAuth();
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const updateAuthor = async (id: string, includeBackCatalog: boolean) => {
+    if (!accessToken) throw new Error('Not authenticated');
+
+    setIsLoading(true);
+    setError(null);
+    try {
+      const response = await fetchWithAuth(`/api/user/watched-authors/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ includeBackCatalog }),
+      });
+      const data = await response.json();
+      if (!response.ok) {
+        throw new Error(data.message || data.error || 'Failed to update watched author');
+      }
+      mutate((key) => typeof key === 'string' && key.includes('/api/user/watched-authors'));
+      return data.author as WatchedAuthorItem;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unknown error';
+      setError(message);
+      throw err;
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return { updateAuthor, isLoading, error };
 }
 
 export function useDeleteWatchedAuthor() {

--- a/src/lib/services/watched-lists.service.ts
+++ b/src/lib/services/watched-lists.service.ts
@@ -244,7 +244,7 @@ async function processAllWatchedAuthors(
 
 async function processAuthorForUsers(
   authorAsin: string,
-  subscriptions: Array<{ id: string; authorName: string; user: { id: string; plexUsername: string } }>,
+  subscriptions: Array<{ id: string; authorName: string; createdAt: Date; includeBackCatalog: boolean; user: { id: string; plexUsername: string } }>,
   log: ReturnType<typeof RMABLogger.forJob> | ReturnType<typeof RMABLogger.create>,
   stats: WatchedListsSyncStats
 ): Promise<void> {
@@ -290,12 +290,19 @@ async function processAuthorForUsers(
     persistDedupGroups(groups).catch(() => {});
   }
 
-  // For each user watching this author, create requests for new books
   for (const subscription of subscriptions) {
+    const followDate = toLocalDateKey(subscription.createdAt);
+    const books = subscription.includeBackCatalog
+      ? dedupedBooks
+      : dedupedBooks.filter((book) => {
+          const releaseDate = book.releaseDate?.slice(0, 10);
+          return !!releaseDate && /^\d{4}-\d{2}-\d{2}$/.test(releaseDate) && releaseDate >= followDate;
+        });
+
     await createRequestsForUser(
       subscription.user.id,
       subscription.user.plexUsername,
-      dedupedBooks,
+      books,
       log,
       stats
     );
@@ -308,6 +315,13 @@ async function processAuthorForUsers(
   }
 
   stats.authorsChecked++;
+}
+
+function toLocalDateKey(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/api/watched-authors.routes.test.ts
+++ b/tests/api/watched-authors.routes.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Component: Watched Authors API Route Tests
+ * Documentation: documentation/features/watched-lists.md
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createPrismaMock } from '../helpers/prisma';
+
+let authRequest: any;
+
+const requireAuthMock = vi.hoisted(() => vi.fn());
+const prismaMock = createPrismaMock();
+const jobQueueMock = vi.hoisted(() => ({
+  addCheckWatchedItemJob: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock('@/lib/middleware/auth', () => ({ requireAuth: requireAuthMock }));
+vi.mock('@/lib/db', () => ({ prisma: prismaMock }));
+vi.mock('@/lib/services/job-queue.service', () => ({
+  getJobQueueService: () => jobQueueMock,
+}));
+
+const WATCHED_AUTHOR = {
+  id: 'wa-1',
+  userId: 'user-1',
+  authorAsin: 'B001AUTH01',
+  authorName: 'Author A',
+  coverArtUrl: null,
+  includeBackCatalog: false,
+  lastCheckedAt: null,
+  createdAt: new Date('2026-08-01T12:00:00Z'),
+  updatedAt: new Date('2026-08-01T12:00:00Z'),
+};
+
+describe('watched author catalog mode', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authRequest = {
+      user: { id: 'user-1', role: 'user' },
+      json: vi.fn(),
+    };
+    requireAuthMock.mockImplementation((_req: any, handler: any) => handler(authRequest));
+  });
+
+  it('defaults new watched authors to new releases only', async () => {
+    authRequest.json.mockResolvedValue({
+      authorAsin: 'B001AUTH01',
+      authorName: 'Author A',
+    });
+    prismaMock.watchedAuthor.findUnique.mockResolvedValue(null);
+    prismaMock.watchedAuthor.create.mockResolvedValue(WATCHED_AUTHOR);
+
+    const { POST } = await import('@/app/api/user/watched-authors/route');
+    const response = await POST({} as any);
+
+    expect(response.status).toBe(201);
+    expect(prismaMock.watchedAuthor.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({ includeBackCatalog: false }),
+    });
+  });
+
+  it('updates the mode and checks the author when back catalog is enabled', async () => {
+    authRequest.json.mockResolvedValue({ includeBackCatalog: true });
+    prismaMock.watchedAuthor.findUnique.mockResolvedValue(WATCHED_AUTHOR);
+    prismaMock.watchedAuthor.update.mockResolvedValue({ ...WATCHED_AUTHOR, includeBackCatalog: true });
+
+    const { PATCH } = await import('@/app/api/user/watched-authors/[id]/route');
+    const response = await PATCH({} as any, { params: Promise.resolve({ id: 'wa-1' }) });
+
+    expect(response.status).toBe(200);
+    expect(prismaMock.watchedAuthor.update).toHaveBeenCalledWith({
+      where: { id: 'wa-1' },
+      data: { includeBackCatalog: true },
+    });
+    expect(jobQueueMock.addCheckWatchedItemJob).toHaveBeenCalledWith(
+      'user-1',
+      undefined,
+      'B001AUTH01'
+    );
+  });
+
+  it('does not allow another user to change the mode', async () => {
+    authRequest.json.mockResolvedValue({ includeBackCatalog: true });
+    prismaMock.watchedAuthor.findUnique.mockResolvedValue({ ...WATCHED_AUTHOR, userId: 'user-2' });
+
+    const { PATCH } = await import('@/app/api/user/watched-authors/[id]/route');
+    const response = await PATCH({} as any, { params: Promise.resolve({ id: 'wa-1' }) });
+
+    expect(response.status).toBe(403);
+    expect(prismaMock.watchedAuthor.update).not.toHaveBeenCalled();
+  });
+});

--- a/tests/services/watched-lists.service.test.ts
+++ b/tests/services/watched-lists.service.test.ts
@@ -195,6 +195,8 @@ describe('processWatchedLists', () => {
         authorAsin: 'B001AUTH001',
         authorName: 'Author A',
         coverArtUrl: null,
+        includeBackCatalog: true,
+        createdAt: new Date(2026, 0, 15, 12),
         lastCheckedAt: null,
         user: { id: 'user-1', plexUsername: 'testuser' },
       },
@@ -227,6 +229,43 @@ describe('processWatchedLists', () => {
     expect(stats.authorsChecked).toBe(1);
     expect(stats.requestsCreated).toBe(1);
     expect(mockSearchByAuthorAsin).toHaveBeenCalledWith('Author A', 'B001AUTH001', 1);
+  });
+
+  it('only requests releases on or after the follow date by default', async () => {
+    const followedAt = new Date(2026, 0, 15, 12);
+    prismaMock.watchedSeries.findMany.mockResolvedValue([]);
+    prismaMock.watchedAuthor.findMany.mockResolvedValue([
+      {
+        id: 'wa-1',
+        userId: 'user-1',
+        authorAsin: 'B001AUTH001',
+        authorName: 'Author A',
+        coverArtUrl: null,
+        includeBackCatalog: false,
+        createdAt: followedAt,
+        lastCheckedAt: null,
+        user: { id: 'user-1', plexUsername: 'testuser' },
+      },
+    ]);
+    prismaMock.watchedAuthor.update.mockResolvedValue({});
+
+    const books = [
+      { asin: 'OLD0000001', title: 'Old Book', author: 'Author A', releaseDate: '2026-01-14' },
+      { asin: 'NEW0000001', title: 'New Book', author: 'Author A', releaseDate: '2026-01-15' },
+      { asin: 'UND0000001', title: 'Undated Book', author: 'Author A' },
+    ];
+    mockSearchByAuthorAsin.mockResolvedValueOnce({ books, hasMore: false, page: 1, totalResults: 3 });
+    mockDeduplicateAndCollectGroups.mockReturnValue({ books, groups: [] });
+    mockCreateRequestForUser.mockResolvedValue({ success: true, request: {} });
+
+    const { processWatchedLists } = await import('@/lib/services/watched-lists.service');
+    await processWatchedLists();
+
+    expect(mockCreateRequestForUser).toHaveBeenCalledTimes(1);
+    expect(mockCreateRequestForUser).toHaveBeenCalledWith(
+      'user-1',
+      expect.objectContaining({ asin: 'NEW0000001' })
+    );
   });
 
   it('counts duplicate/already-available books as skippedExisting', async () => {
@@ -485,6 +524,8 @@ describe('processWatchedLists', () => {
         authorAsin: 'B001AUTH001',
         authorName: 'Target Author',
         coverArtUrl: null,
+        includeBackCatalog: true,
+        createdAt: new Date(2026, 0, 15, 12),
         lastCheckedAt: null,
         user: { id: 'user-1', plexUsername: 'testuser' },
       },


### PR DESCRIPTION
## Summary

- Add per-author catalog mode: New releases only or Entire catalog.
- Default new follows to New releases only using the follow date as the cutoff.
- Preserve existing subscriptions as Entire catalog during migration.
- Allow changing the mode later from the profile page.
- Trigger an immediate watched-list check when switching to Entire catalog.
- Leave watched-series behavior unchanged.

Related to #188.

## Validation

- `npm test` - 2621 passed
- `npm run build` - passed
- `npx prisma validate` - passed
- Migration smoke test: existing watched-author rows become `include_back_catalog = true`; newly inserted rows default to `false`
- `docker compose build readmeabook` - command exits successfully; the current compose file reports no services to build
