### PR TITLE
feat: Add primaryAuthor template variable for file organization

### DIFF
--- a/documentation/settings-pages.md
+++ b/documentation/settings-pages.md
@@ -182,8 +182,9 @@ src/app/admin/settings/
 
 **Configuration:**
 - Key: `audiobook_path_template` (string, default: `{author}/{title} {asin}`)
-- Variables: `{author}`, `{title}`, `{narrator}`, `{asin}`, `{year}`
-- Optional variables (narrator, asin, year) removed if not available
+- Variables: `{author}`, `{primaryAuthor}`, `{title}`, `{narrator}`, `{asin}`, `{year}`, `{series}`, `{seriesPart}`
+- `{primaryAuthor}` contains the first entry from the full `{author}` value
+- Optional variables are removed if not available
 - Template validated on test, shows preview examples
 
 **UI (PathsTab):**
@@ -194,12 +195,15 @@ src/app/admin/settings/
 - Preview examples showing 2-3 sample paths with actual data
 
 **Validation:**
-- Must contain at least `{author}` or `{title}` (required variables)
-- Cannot be empty or only contain optional variables
-- Invalid templates show error message
+- Cannot be empty
+- Any template variables used must be supported
+- Must be a relative path
+- Invalid path characters outside template variables are rejected
+- Invalid templates show an error message
 - Valid templates show preview paths
 
 **Examples:**
+- `{primaryAuthor}/{title}` → `Douglas Adams/The Hitchhiker's Guide to the Galaxy/`
 - `{author}/{title} {asin}` → `Douglas Adams/The Hitchhiker's Guide to the Galaxy B0009JKV9W/`
 - `{author}/{title} ({year})` → `Douglas Adams/The Hitchhiker's Guide to the Galaxy (2005)/`
 - `{author}/{narrator}/{title}` → `Douglas Adams/Stephen Fry/The Hitchhiker's Guide to the Galaxy/`

--- a/src/app/admin/settings/tabs/PathsTab/PathsTab.tsx
+++ b/src/app/admin/settings/tabs/PathsTab/PathsTab.tsx
@@ -341,6 +341,10 @@ export function PathsTab({ paths, onChange, onValidationChange }: PathsTabProps)
             <span className="text-gray-600 dark:text-gray-400 ml-2">- Book author</span>
           </div>
           <div>
+            <code className="text-blue-700 dark:text-blue-300 font-mono">{'{primaryAuthor}'}</code>
+            <span className="text-gray-600 dark:text-gray-400 ml-2">- First author in author list</span>
+          </div>
+          <div>
             <code className="text-blue-700 dark:text-blue-300 font-mono">{'{title}'}</code>
             <span className="text-gray-600 dark:text-gray-400 ml-2">- Book title</span>
           </div>

--- a/src/lib/utils/PATH_TEMPLATE_README.md
+++ b/src/lib/utils/PATH_TEMPLATE_README.md
@@ -15,10 +15,31 @@ Provides template variable substitution, validation, and preview generation for 
 
 ## Supported Variables
 
-- `{author}` - Audiobook author name
+- `{author}` - Full audiobook author string
+- `{primaryAuthor}` - First author in the author list
 - `{title}` - Audiobook title
 - `{narrator}` - Audiobook narrator (optional)
 - `{asin}` - Amazon ASIN identifier (optional)
+- `{year}` - Release year (optional)
+- `{series}` - Series name (optional)
+- `{seriesPart}` - Series part or position (optional)
+
+### Primary Author
+
+`{primaryAuthor}` is derived from `{author}` by taking the first entry in a comma-separated author list.
+`{author}` remains unchanged and continues to contain the full author string.
+
+````markdown
+```typescript
+const result = substituteTemplate(
+  '{primaryAuthor}/{title}',
+  {
+    author: 'Victoria Aveyard, Birgit Schmitz - Übersetzer',
+    title: 'Wütender Sturm'
+  }
+);
+
+// Returns: "Victoria Aveyard/Wütender Sturm"
 
 ## API Reference
 
@@ -95,7 +116,7 @@ Get list of valid template variable names.
 **Example:**
 ```typescript
 const variables = getValidVariables();
-// Returns: ['author', 'title', 'narrator', 'asin']
+// Returns: ['author', 'primaryAuthor', 'title', 'narrator', 'asin', 'year', 'series', 'seriesPart']
 ```
 
 ## Usage Examples

--- a/src/lib/utils/path-template.util.ts
+++ b/src/lib/utils/path-template.util.ts
@@ -11,6 +11,7 @@
  */
 export interface TemplateVariables {
   author: string;
+  primaryAuthor?: string;
   title: string;
   narrator?: string;
   asin?: string;
@@ -30,7 +31,7 @@ export interface ValidationResult {
 /**
  * Supported template variable names
  */
-const VALID_VARIABLES = ['author', 'title', 'narrator', 'asin', 'year', 'series', 'seriesPart'];
+const VALID_VARIABLES = ['author', 'primaryAuthor', 'title', 'narrator', 'asin', 'year', 'series', 'seriesPart'];
 
 /**
  * Invalid file path characters (outside of template variables)
@@ -66,6 +67,33 @@ function sanitizePath(name: string): string {
       // Limit length (255 chars max for most filesystems)
       .slice(0, 200)
   );
+}
+
+/**
+ * Extract the primary author from a comma-separated author list.
+ *
+ * Example:
+ * "Victoria Aveyard, Birgit Schmitz - Übersetzer"
+ * -> "Victoria Aveyard"
+ */
+function getPrimaryAuthor(author: string): string {
+  const primaryAuthor = author.split(',')[0]?.trim();
+
+  return primaryAuthor || author.trim();
+}
+
+/**
+ * Resolve a template variable, including derived variables.
+ */
+function getTemplateVariableValue(
+  variable: string,
+  variables: TemplateVariables
+): string | number | undefined {
+  if (variable === 'primaryAuthor') {
+    return variables.primaryAuthor ?? getPrimaryAuthor(variables.author);
+  }
+
+  return variables[variable as keyof TemplateVariables];
 }
 
 /**
@@ -120,7 +148,7 @@ function resolveConditionalBlocks(
 
     // Check if all found variables have non-empty values
     const allPresent = foundVars.every(varName => {
-      const value = variables[varName as keyof TemplateVariables];
+      const value = getTemplateVariableValue(varName, variables);
       return value !== undefined && value !== null && String(value).trim() !== '';
     });
 
@@ -133,7 +161,7 @@ function resolveConditionalBlocks(
     let result = content;
     const sortedVars = [...foundVars].sort((a, b) => b.length - a.length);
     for (const varName of sortedVars) {
-      const value = variables[varName as keyof TemplateVariables];
+      const value = getTemplateVariableValue(varName, variables);
       const sanitizedValue = sanitizePath(String(value).trim());
       const regex = new RegExp(`(?<![a-zA-Z0-9])${varName}(?![a-zA-Z0-9])`, 'g');
       result = result.replace(regex, sanitizedValue);
@@ -179,7 +207,7 @@ export function substituteTemplate(
 
   // Substitute each variable
   for (const key of VALID_VARIABLES) {
-    const value = variables[key as keyof TemplateVariables];
+    const value = getTemplateVariableValue(key, variables);
     const regex = new RegExp(`\\{${key}\\}`, 'g');
 
     if (value !== undefined && value !== null) {

--- a/tests/lib/utils/path-template.util.test.ts
+++ b/tests/lib/utils/path-template.util.test.ts
@@ -15,6 +15,60 @@ import {
 } from '@/lib/utils/path-template.util';
 
 describe('substituteTemplate', () => {
+  it('substitutes primaryAuthor with the first author', () => {
+    const template = '{primaryAuthor}/{title}';
+
+    const variables: TemplateVariables = {
+      author: 'Victoria Aveyard, Birgit Schmitz - Übersetzer',
+      title: 'Wütender Sturm'
+    };
+
+    const result = substituteTemplate(template, variables);
+
+    expect(result).toBe('Victoria Aveyard/Wütender Sturm');
+  });
+
+  it('keeps the full author list when using author', () => {
+    const template = '{author}/{title}';
+
+    const variables: TemplateVariables = {
+      author: 'Victoria Aveyard, Birgit Schmitz - Übersetzer',
+      title: 'Wütender Sturm'
+    };
+
+    const result = substituteTemplate(template, variables);
+
+    expect(result).toBe(
+      'Victoria Aveyard, Birgit Schmitz - Übersetzer/Wütender Sturm'
+    );
+  });
+
+  it('uses the author unchanged as primaryAuthor when there is only one author', () => {
+    const template = '{primaryAuthor}/{title}';
+
+    const variables: TemplateVariables = {
+      author: 'Andrzej Sapkowski',
+      title: 'Das Erbe der Elfen'
+    };
+
+    const result = substituteTemplate(template, variables);
+
+    expect(result).toBe('Andrzej Sapkowski/Das Erbe der Elfen');
+  });
+
+  it('uses the first author for multiple actual authors', () => {
+    const template = '{primaryAuthor}/{title}';
+
+    const variables: TemplateVariables = {
+      author: 'Douglas Preston, Lincoln Child',
+      title: 'Relic'
+    };
+
+    const result = substituteTemplate(template, variables);
+
+    expect(result).toBe('Douglas Preston/Relic');
+  });
+
   it('should substitute all valid variables', () => {
     const template = '{author}/{title}/{narrator}/{asin}';
     const variables: TemplateVariables = {
@@ -355,6 +409,18 @@ describe('substituteTemplate', () => {
 });
 
 describe('validateTemplate', () => {
+  it('should accept primaryAuthor as a valid variable', () => {
+    const result = validateTemplate('{primaryAuthor}/{title}');
+
+    expect(result.valid).toBe(true);
+  });
+
+  it('should accept primaryAuthor in conditional blocks', () => {
+    const result = validateTemplate('{primaryAuthor - }{title}');
+
+    expect(result.valid).toBe(true);
+  });
+
   it('should accept valid templates', () => {
     const templates = [
       '{author}/{title}',
@@ -595,13 +661,14 @@ describe('getValidVariables', () => {
     const variables = getValidVariables();
 
     expect(variables).toContain('author');
+    expect(variables).toContain('primaryAuthor');
     expect(variables).toContain('title');
     expect(variables).toContain('narrator');
     expect(variables).toContain('asin');
     expect(variables).toContain('year');
     expect(variables).toContain('series');
     expect(variables).toContain('seriesPart');
-    expect(variables).toHaveLength(7);
+    expect(variables).toHaveLength(8);
   });
 
   it('should return a new array each time (not mutate original)', () => {


### PR DESCRIPTION
Adds a new `{primaryAuthor}` template variable for audiobook path and filename organization.

`{primaryAuthor}` defaults to the first entry in the comma-separated `{author}` value, while `{author}` continues to expose the full author string.

Example:
- `{author}` → `Victoria Aveyard, Birgit Schmitz - narrator`
- `{primaryAuthor}` → `Victoria Aveyard`

## Changes
- Add `{primaryAuthor}` to supported template variables
- Support it in normal and conditional template substitution
- Add it to the Paths settings variable reference
- Update template documentation
- Add validation and substitution tests

## Validation
- 90/90 path-template tests pass
- Full test suite passes
- Tested with a real audiobook import using multi-author metadata
- Verified for both folder paths and filename templates