### PR TITLE
Accept qBittorrent 5.2 torrent-add responses

### DIFF
--- a/documentation/phase3/qbittorrent.md
+++ b/documentation/phase3/qbittorrent.md
@@ -6,7 +6,12 @@ Free, open-source BitTorrent client with comprehensive Web API.
 
 ## Enterprise Torrent Addition
 
-**Challenge:** `/api/v2/torrents/add` returns only "Ok." without torrent hash.
+**Responses:** `/api/v2/torrents/add` returns legacy `Ok.` or a JSON receipt in qBittorrent 5.2.
+
+- Both magnet and file uploads accept `Ok.` for compatibility with older clients.
+- JSON must confirm exactly the submitted hash (case-insensitive): `success_count: 1`, `failure_count: 0`, `pending_count: 0`, and one matching `added_torrent_ids` entry.
+- Pending, malformed, mismatched and rejected responses remain errors; HTTP 200 alone does not confirm the add.
+- Hash extraction and the existing duplicate check are unchanged.
 
 **Solution (Professional):**
 

--- a/src/lib/integrations/qbittorrent.service.ts
+++ b/src/lib/integrations/qbittorrent.service.ts
@@ -303,6 +303,19 @@ export class QBittorrentService implements IDownloadClient {
     }
   }
 
+  /** Accept legacy success or a qBittorrent 5.2 receipt for our single submitted hash. */
+  private isAddAccepted(data: unknown, infoHash: string): boolean {
+    if (data === 'Ok.') return true;
+    if (!data || typeof data !== 'object' || Array.isArray(data)) return false;
+
+    const receipt = data as Record<string, unknown>;
+    return receipt.success_count === 1 && receipt.failure_count === 0 &&
+      receipt.pending_count === 0 && Array.isArray(receipt.added_torrent_ids) &&
+      receipt.added_torrent_ids.length === 1 &&
+      typeof receipt.added_torrent_ids[0] === 'string' &&
+      receipt.added_torrent_ids[0].toLowerCase() === infoHash.toLowerCase();
+  }
+
   /**
    * Add magnet link - hash is extractable from URI (deterministic)
    */
@@ -358,7 +371,7 @@ export class QBittorrentService implements IDownloadClient {
       },
     });
 
-    if (response.data !== 'Ok.') {
+    if (!this.isAddAccepted(response.data, infoHash)) {
       throw new Error(`qBittorrent rejected magnet link: ${response.data}`);
     }
 
@@ -529,7 +542,7 @@ export class QBittorrentService implements IDownloadClient {
       maxContentLength: Infinity,
     });
 
-    if (response.data !== 'Ok.') {
+    if (!this.isAddAccepted(response.data, infoHash)) {
       throw new Error(`qBittorrent rejected .torrent file: ${response.data}`);
     }
 

--- a/tests/integrations/qbittorrent-add-response.test.ts
+++ b/tests/integrations/qbittorrent-add-response.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Component: qBittorrent Add Response Compatibility Tests
+ * Documentation: documentation/phase3/qbittorrent.md
+ */
+
+import { createHash } from 'node:crypto';
+import { createServer, type Server } from 'node:http';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { QBittorrentService } from '@/lib/integrations/qbittorrent.service';
+
+vi.mock('@/lib/utils/logger', () => ({
+  RMABLogger: { create: () => ({ info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() }) },
+}));
+
+// Minimal trackerless torrent; exercise the real parser and multipart upload.
+const info = Buffer.from(`d6:lengthi1e4:name8:Book.txt12:piece lengthi16384e6:pieces20:${'x'.repeat(20)}e`);
+const torrent = Buffer.concat([Buffer.from('d4:info'), info, Buffer.from('e')]);
+const hash = createHash('sha1').update(info).digest('hex');
+const receipt = {
+  success_count: 1,
+  failure_count: 0,
+  pending_count: 0,
+  added_torrent_ids: [hash],
+};
+
+describe('qBittorrent add responses over HTTP', () => {
+  let server: Server;
+  let baseUrl: string;
+  let response: unknown;
+  let status: number;
+  let existing: boolean;
+  let uploads: { contentType: string; body: Buffer }[];
+
+  beforeAll(async () => {
+    server = createServer(async (req, res) => {
+      const pathname = new URL(req.url!, 'http://localhost').pathname;
+      if (pathname === '/book.torrent') {
+        res.end(torrent);
+      } else if (pathname === '/api/v2/torrents/categories') {
+        res.setHeader('Content-Type', 'application/json');
+        res.end(JSON.stringify({ readmeabook: { savePath: '/downloads' } }));
+      } else if (pathname === '/api/v2/torrents/info') {
+        res.setHeader('Content-Type', 'application/json');
+        res.end(JSON.stringify(existing ? [{ hash }] : []));
+      } else if (pathname === '/api/v2/torrents/add') {
+        const chunks: Buffer[] = [];
+        for await (const chunk of req) chunks.push(Buffer.from(chunk));
+        uploads.push({ contentType: req.headers['content-type'] || '', body: Buffer.concat(chunks) });
+        res.statusCode = status;
+        res.setHeader('Content-Type', typeof response === 'string' ? 'text/plain' : 'application/json');
+        res.end(typeof response === 'string' ? response : JSON.stringify(response));
+      } else {
+        res.writeHead(404).end();
+      }
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(0, '127.0.0.1', resolve);
+    });
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('Missing test server port');
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterAll(async () => {
+    if (!server.listening) return;
+    await new Promise<void>((resolve, reject) => server.close(error => error ? reject(error) : resolve()));
+  });
+
+  beforeEach(() => {
+    response = receipt;
+    status = 200;
+    existing = false;
+    uploads = [];
+  });
+
+  describe.each(['magnet', 'file'] as const)('%s', kind => {
+    const add = () => new QBittorrentService(baseUrl, '', '').addTorrent(
+      kind === 'magnet' ? `magnet:?xt=urn:btih:${hash}` : `${baseUrl}/book.torrent`
+    );
+
+    it.each([
+      ['legacy success', 'Ok.'],
+      ['5.2 success', receipt],
+      ['case-insensitive hash', { ...receipt, added_torrent_ids: [hash.toUpperCase()] }],
+    ])('accepts %s and returns the submitted hash', async (_label, body) => {
+      response = body;
+      await expect(add()).resolves.toBe(hash);
+      expect(uploads).toHaveLength(1);
+      if (kind === 'magnet') {
+        expect(uploads[0].contentType).toContain('application/x-www-form-urlencoded');
+        expect(new URLSearchParams(uploads[0].body.toString()).get('urls')).toBe(`magnet:?xt=urn:btih:${hash}`);
+      } else {
+        expect(uploads[0].contentType).toContain('multipart/form-data');
+        expect(uploads[0].body.includes(torrent)).toBe(true);
+      }
+    });
+
+    it.each([
+      ['empty body', ''],
+      ['legacy rejection', 'Fails.'],
+      ['HTML response', '<html>login</html>'],
+      ['null', null],
+      ['array', [receipt]],
+      ['missing fields', { success_count: 1 }],
+      ['failure', { ...receipt, failure_count: 1 }],
+      ['pending', { ...receipt, pending_count: 1 }],
+      ['no success', { ...receipt, success_count: 0 }],
+      ['string count', { ...receipt, success_count: '1' }],
+      ['wrong hash', { ...receipt, added_torrent_ids: ['0'.repeat(40)] }],
+      ['missing hash', { ...receipt, added_torrent_ids: [] }],
+      ['non-string hash', { ...receipt, added_torrent_ids: [123] }],
+      ['extra hash', { ...receipt, added_torrent_ids: [hash, '0'.repeat(40)] }],
+      ['multiple successes', { ...receipt, success_count: 2 }],
+    ])('rejects %s despite HTTP 200', async (_label, body) => {
+      response = body;
+      await expect(add()).rejects.toThrow('Failed to add torrent to qBittorrent');
+      expect(uploads).toHaveLength(1);
+    });
+
+    it('rejects an asynchronous receipt without a confirmed hash', async () => {
+      status = 202;
+      response = { success_count: 0, failure_count: 0, pending_count: 1, added_torrent_ids: [] };
+      await expect(add()).rejects.toThrow('Failed to add torrent to qBittorrent');
+    });
+
+    it('still rejects HTTP errors with a success-shaped body', async () => {
+      status = 409;
+      await expect(add()).rejects.toThrow('Failed to add torrent to qBittorrent');
+    });
+
+    it('returns existing downloads without submitting them again', async () => {
+      existing = true;
+      await expect(add()).resolves.toBe(hash);
+      expect(uploads).toHaveLength(0);
+    });
+  });
+});


### PR DESCRIPTION
qBittorrent 5.2 returns a JSON receipt after adding a torrent ([upstream change](https://github.com/qbittorrent/qBittorrent/pull/23202)). RMAB currently requires `Ok.`, so it reports a failure even when the client accepted the download.

Accept both formats for magnets and `.torrent` uploads. JSON receipts must confirm exactly the submitted hash, with one success and no failures or pending additions. Existing duplicate handling stays unchanged.

Validation covers both upload paths over local HTTP with real Axios and torrent parsing: legacy/JSON success, malformed or mismatched receipts, pending additions, HTTP errors and existing downloads. The JSON success cases reproduce the bug against unchanged `main`. Full test suite, TypeScript, Next.js production build and isolated Docker image build pass.

Developed with AI assistance using OpenAI Codex (GPT-6 Astra), with human review.
